### PR TITLE
:sparkles: format button

### DIFF
--- a/src/components/input-panel/spec-editor/index.css
+++ b/src/components/input-panel/spec-editor/index.css
@@ -1,19 +1,21 @@
 .sizeFixEditorParent .react-monaco-editor-container {
-    overflow: hidden;
-}
-
-#parse-button {
-    position: absolute;
-    right: 3%;
-    cursor: pointer;
+  overflow: hidden;
 }
 
 .editor-header {
-    font-size: 12px;
-    width: 100%;
-    height: 25px;
-    flex-shrink: 0;
-    background-color: #e6e6e6;
-    display: flex;
-    align-items: center;
+  font-size: 12px;
+  width: 100%;
+  height: 25px;
+  flex-shrink: 0;
+  background-color: #e6e6e6;
+  display: flex;
+  align-items: center;
+}
+
+.editor-header.right-align {
+  justify-content: flex-end;
+}
+
+.button {
+  margin-right: 8px;
 }

--- a/src/components/input-panel/spec-editor/renderer.tsx
+++ b/src/components/input-panel/spec-editor/renderer.tsx
@@ -104,11 +104,9 @@ class Editor extends React.Component<Props, State> {
   public manualParseSpec() {
     if (!this.props.autoParse) {
       return (
-        <div className='editor-header'>
-          <button id='parse-button' onClick={() => this.props.parseSpec(true)}>
-            Parse
-          </button>
-        </div>
+        <button id='parse-button' className='button' onClick={() => this.props.parseSpec(true)}>
+          Parse
+        </button>
       );
     }
   }
@@ -143,12 +141,29 @@ class Editor extends React.Component<Props, State> {
     }
   }
 
+  /**
+   * Formats the editor code.
+   * Triggered by #format-button on click.
+   */
+  public formatDocument() {
+    (this.refs.vegaEditor as any)
+      .editor
+      .getAction('editor.action.formatDocument')
+      .run();
+  }
+
   public render() {
     const code = this.state.code;
     return (
       <div className={'full-height-wrapper'}>
-        {this.manualParseSpec()}
+        <div className='editor-header right-align'>
+          <button id='format-button' className='button' onClick={() => this.formatDocument()}>
+            Format
+          </button>
+          {this.manualParseSpec()}
+        </div>
         <MonacoEditor
+          ref='vegaEditor'
           language='json'
           options={{
             folding: true,


### PR DESCRIPTION
Adding a 'Format' button to the editor header.
Refer to the Issue #37 
![36946788-6266b0b2-1fe8-11e8-91cd-ff564709b94f](https://user-images.githubusercontent.com/2150306/37015590-1d5a82b8-212e-11e8-87ef-e057091afbdb.gif)
