### PR TITLE
Fix: Remove unnecessary scrollbar (in few browsers)

### DIFF
--- a/src/components/viz-pane/index.css
+++ b/src/components/viz-pane/index.css
@@ -5,3 +5,7 @@
   padding: 10px;
   overflow: auto;
 }
+
+.Pane::-webkit-scrollbar {
+    display: none;
+}


### PR DESCRIPTION
**Fix: Remove extra scroll (in few browsers)**

- In few browsers (like Chrome 64.0), there is an unnecessary disabled scrollbar associated with chart container, which looks like this:
![image](https://user-images.githubusercontent.com/21237466/37215708-c2e83a92-23de-11e8-89a2-d2c140287044.png)

- After fix:
![image](https://user-images.githubusercontent.com/21237466/37215758-e27a613c-23de-11e8-9fc7-b206ec0dd553.png)
