### PR TITLE
[WIP] Use vega-loader for validating links

### DIFF
--- a/src/actions/editor.ts
+++ b/src/actions/editor.ts
@@ -3,6 +3,7 @@ import {Mode, Renderer} from '../constants';
 export const EXPORT_VEGA: 'EXPORT_VEGA' = 'EXPORT_VEGA';
 export const LOG_ERROR: 'LOG_ERROR' = 'LOG_ERROR';
 export const PARSE_SPEC: 'PARSE_SPEC' = 'PARSE_SPEC';
+export const SET_BASEURL: 'SET_BASEURL' = 'SET_BASEURL';
 export const SET_GIST_VEGA_LITE_SPEC: 'SET_GIST_VEGA_LITE_SPEC' = 'SET_GIST_VEGA_LITE_SPEC';
 export const SET_GIST_VEGA_SPEC: 'SET_GIST_VEGA_SPEC' = 'SET_GIST_VEGA_SPEC';
 export const SET_MODE: 'SET_MODE' = 'SET_MODE';
@@ -17,7 +18,7 @@ export const UPDATE_EDITOR_STRING: 'UPDATE_EDITOR_STRING' = 'UPDATE_EDITOR_STRIN
 export const UPDATE_VEGA_LITE_SPEC: 'UPDATE_VEGA_LITE_SPEC' = 'UPDATE_VEGA_LITE_SPEC';
 export const UPDATE_VEGA_SPEC: 'UPDATE_VEGA_SPEC' = 'UPDATE_VEGA_SPEC';
 
-export type Action = SetMode | ParseSpec | SetVegaExample | SetVegaLiteExample | UpdateVegaSpec | UpdateVegaLiteSpec | SetGistVegaSpec | SetGistVegaLiteSpec | ToggleAutoParse | ShowCompiledVegaSpec | ShowErrorPane | LogError | UpdateEditorString | ShowTooltip | ExportVega | SetRenderer;
+export type Action = SetMode | ParseSpec | SetVegaExample | SetVegaLiteExample | UpdateVegaSpec | UpdateVegaLiteSpec | SetGistVegaSpec | SetGistVegaLiteSpec | ToggleAutoParse | ShowCompiledVegaSpec | ShowErrorPane | LogError | UpdateEditorString | ShowTooltip | ExportVega | SetRenderer | SetBaseUrl;
 
 export function setMode(mode: Mode) {
   return {
@@ -146,3 +147,11 @@ export function setRenderer(renderer: Renderer) {
   };
 }
 export type SetRenderer = ReturnType<typeof setRenderer>;
+
+export function setBaseUrl(val: string) {
+  return {
+    type: SET_BASEURL,
+    baseURL: val,
+  };
+}
+export type SetBaseUrl = ReturnType<typeof setBaseUrl>;

--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -25,6 +25,8 @@ class App extends React.Component<Props & {match: any, location: any}> {
         if (!data.spec) {
           return;
         }
+        // setting baseURL as event's origin
+        this.props.setBaseUrl(evt.origin);
         console.info('[Vega-Editor] Received Message', evt.origin, data);
         // send acknowledgement
         const parsed = JSON.parse(data.spec);
@@ -141,6 +143,9 @@ const mapDispatchToProps = function(dispatch) {
     },
     updateVegaLiteSpec: (val) => {
       dispatch(EditorActions.updateVegaLiteSpec(val));
+    },
+    setBaseUrl: (val) => {
+      dispatch(EditorActions.setBaseUrl(val));
     },
     setVegaExample: (example: string, val) => {
       dispatch(EditorActions.setVegaExample(example, val));

--- a/src/components/renderer/index.tsx
+++ b/src/components/renderer/index.tsx
@@ -11,6 +11,7 @@ function mapStateToProps(state: State, ownProps) {
     mode: state.mode,
     tooltip: state.tooltip,
     export: state.export,
+    baseURL: state.baseURL,
   };
 }
 

--- a/src/components/renderer/renderer.tsx
+++ b/src/components/renderer/renderer.tsx
@@ -32,7 +32,8 @@ export default class Editor extends React.Component<Props> {
     // Custom Loader
     loader.load = async(url, options) => {
       try {
-        return await originalLoad(url, {options, ...{baseURL: this.props.baseURL}});
+        if (options) return await originalLoad(url, {...options, ...{baseURL: this.props.baseURL}});
+        return await originalLoad(url, {baseURL: this.props.baseURL});
       } catch {
         return await originalLoad(url, options);
       }

--- a/src/constants/default-state.ts
+++ b/src/constants/default-state.ts
@@ -3,6 +3,7 @@ import {Mode, Renderer} from './consts';
 
 export type State = {
   autoParse: boolean;
+  baseURL: string;
   compiledVegaSpec: boolean;
   editorString: string;
   error: Error;
@@ -21,6 +22,7 @@ export type State = {
 
 export const DEFAULT_STATE: State = {
   autoParse: true,
+  baseURL: null,
   compiledVegaSpec: false,
   editorString: '{}',
   error: null,

--- a/src/reducers/index.ts
+++ b/src/reducers/index.ts
@@ -5,6 +5,7 @@ import {
   EXPORT_VEGA,
   LOG_ERROR,
   PARSE_SPEC,
+  SET_BASEURL,
   SET_GIST_VEGA_LITE_SPEC,
   SET_GIST_VEGA_SPEC,
   SET_MODE,
@@ -126,6 +127,7 @@ export default (state: State = DEFAULT_STATE, action: Action): State => {
         warningsLogger: new LocalLogger(),
         tooltip: true,
         export: false,
+        baseURL: null,
       };
     case PARSE_SPEC:
       return {
@@ -198,6 +200,11 @@ export default (state: State = DEFAULT_STATE, action: Action): State => {
       return {
         ...state,
         renderer: action.renderer,
+      };
+    case SET_BASEURL:
+      return {
+        ...state,
+        baseURL: action.baseURL,
       };
     default:
       return state;


### PR DESCRIPTION
**Use vega-loader for validating links**

- It first checks whether the link is `absolute` or `relative to the editor`. If gets `404` then check whether it is `relative to the caller` and if still gets an error then throws it. 

Fixes #30.