### PR TITLE
Apply config to visualization that is posted from vega-embed and upgrade vega-lite

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "redux-thunk": "^2.2.0",
     "vega": "github:vega/vega#v3.2.1",
     "vega-datasets": "^1.18.0",
-    "vega-lite": "github:vega/vega-lite#v2.3.0",
+    "vega-lite": "github:vega/vega-lite#v2.3.1",
     "vega-schema-url-parser": "^1.0.0",
     "vega-tooltip": "^0.7.0"
   },

--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -6,7 +6,7 @@ import * as React from 'react';
 import {connect} from 'react-redux';
 import {withRouter} from 'react-router-dom';
 import SplitPane from 'react-split-pane';
-
+import {util} from 'vega-lite';
 import * as EditorActions from '../actions/editor';
 import {LAYOUT, Mode} from '../constants';
 import {NAME_TO_MODE, VEGA_LITE_START_SPEC, VEGA_START_SPEC} from '../constants/consts';
@@ -30,6 +30,8 @@ class App extends React.Component<Props & {match: any, location: any}> {
         console.info('[Vega-Editor] Received Message', evt.origin, data);
         // send acknowledgement
         const parsed = JSON.parse(data.spec);
+        // merging config into the spec
+        if (data.config) util.mergeDeep(parsed, {config: data.config});
         data.spec = JSON.stringify(parsed, null, 2);
         if (data.spec || data.file) {
           evt.source.postMessage(true, '*');

--- a/yarn.lock
+++ b/yarn.lock
@@ -6738,21 +6738,9 @@ vega-hierarchy@^2.1:
     vega-dataflow "3"
     vega-util "1"
 
-vega-lite@^2.3.1:
+vega-lite@^2.3.1, "vega-lite@github:vega/vega-lite#v2.3.1":
   version "2.3.1"
-  resolved "https://registry.yarnpkg.com/vega-lite/-/vega-lite-2.3.1.tgz#a7abd16ef7d06b3f8ed8c873bca4be5c4a577369"
-  dependencies:
-    "@types/json-stable-stringify" "^1.0.32"
-    json-stable-stringify "^1.0.1"
-    tslib "^1.9.0"
-    vega-event-selector "^2.0.0"
-    vega-typings "^0.2.11"
-    vega-util "^1.7.0"
-    yargs "^11.0.0"
-
-"vega-lite@github:vega/vega-lite#v2.3.0":
-  version "2.3.0"
-  resolved "https://codeload.github.com/vega/vega-lite/tar.gz/c115a38e034d58ee4b152d63e5f692b47bf356a0"
+  resolved "https://codeload.github.com/vega/vega-lite/tar.gz/e69cb2844cc096c348fafcf05cba6709991bc02d"
   dependencies:
     "@types/json-stable-stringify" "^1.0.32"
     json-stable-stringify "^1.0.1"


### PR DESCRIPTION
**Apply config to visualization that is posted from vega-embed and upgrade vega-lite**

- Upgrade vega-lite to 2.3.1
- Uses `mergeDeep` to merge config into the spec. 
- Fixes #55.