### PR TITLE
Add keyboard shortcuts

### DIFF
--- a/src/components/input-panel/spec-editor/index.css
+++ b/src/components/input-panel/spec-editor/index.css
@@ -25,7 +25,6 @@
   outline: 0;
 }
 
-.button:active,
-.button-press {
-  box-shadow: 0 0 1px 0 #000;
+.pressed {
+  box-shadow: 0 0 5px 1px steelblue;
 }

--- a/src/components/input-panel/spec-editor/index.css
+++ b/src/components/input-panel/spec-editor/index.css
@@ -17,5 +17,15 @@
 }
 
 .button {
+  user-select: none;
   margin-right: 8px;
+}
+
+.button:focus {
+  outline: 0;
+}
+
+.button:active,
+.button-press {
+  box-shadow: 0 0 1px 0 #000;
 }

--- a/src/components/input-panel/spec-editor/renderer.tsx
+++ b/src/components/input-panel/spec-editor/renderer.tsx
@@ -114,6 +114,11 @@ class Editor extends React.Component<Props, {}> {
       if ((e.keyCode === KEYCODES.B || e.keyCode === KEYCODES.S) && (e.ctrlKey || e.metaKey)) {
         e.preventDefault();
         this.props.parseSpec(true);
+        const parseButton = this.refs.parse as any;
+        parseButton.classList.add('pressed');
+        setTimeout(() => {
+          parseButton.classList.remove('pressed');
+        }, 250);
       }
     }
   }
@@ -155,9 +160,7 @@ class Editor extends React.Component<Props, {}> {
   public componentWillReceiveProps(nextProps: Props) {
     if (!nextProps.autoParse && nextProps.parse) {
       this.updateSpec(nextProps.value);
-      setTimeout(() => {
-        this.props.parseSpec(false);
-      }, 230);
+      this.props.parseSpec(false);
     }
   }
   public componentDidMount() {
@@ -169,11 +172,7 @@ class Editor extends React.Component<Props, {}> {
   public manualParseSpec() {
     if (!this.props.autoParse) {
       return (
-        <button
-          id="parse-button"
-          className={this.props.parse ? 'button button-press' : 'button'}
-          onClick={() => this.props.parseSpec(true)}
-        >
+        <button ref="parse" id="parse-button" className="button" onClick={() => this.props.parseSpec(true)}>
           Parse
         </button>
       );

--- a/src/components/input-panel/spec-editor/renderer.tsx
+++ b/src/components/input-panel/spec-editor/renderer.tsx
@@ -155,7 +155,9 @@ class Editor extends React.Component<Props, {}> {
   public componentWillReceiveProps(nextProps: Props) {
     if (!nextProps.autoParse && nextProps.parse) {
       this.updateSpec(nextProps.value);
-      this.props.parseSpec(false);
+      setTimeout(() => {
+        this.props.parseSpec(false);
+      }, 230);
     }
   }
   public componentDidMount() {
@@ -167,7 +169,11 @@ class Editor extends React.Component<Props, {}> {
   public manualParseSpec() {
     if (!this.props.autoParse) {
       return (
-        <button id="parse-button" className="button" onClick={() => this.props.parseSpec(true)}>
+        <button
+          id="parse-button"
+          className={this.props.parse ? 'button button-press' : 'button'}
+          onClick={() => this.props.parseSpec(true)}
+        >
           Parse
         </button>
       );

--- a/src/components/input-panel/spec-editor/renderer.tsx
+++ b/src/components/input-panel/spec-editor/renderer.tsx
@@ -97,7 +97,22 @@ interface Props {
   updateVegaSpec: (val: any) => void;
 }
 
+const KEYCODES = {
+  B: 66,
+};
+
 class Editor extends React.Component<Props, {}> {
+  constructor(props) {
+    super(props);
+    this.handleKeydown = this.handleKeydown.bind(this);
+    this.handleEditorChange = this.handleEditorChange.bind(this);
+    this.editorWillMount = this.editorWillMount.bind(this);
+  }
+  public handleKeydown(e) {
+    if (e.keyCode === KEYCODES.B && e.ctrlKey && !this.props.autoParse) {
+      this.props.parseSpec(true);
+    }
+  }
   public editorDidMount(editor) {
     editor.focus();
   }
@@ -138,6 +153,12 @@ class Editor extends React.Component<Props, {}> {
       this.updateSpec(nextProps.value);
       this.props.parseSpec(false);
     }
+  }
+  public componentDidMount() {
+    document.addEventListener('keydown', this.handleKeydown);
+  }
+  public componentWillUnmount() {
+    document.removeEventListener('keydown', this.handleKeydown);
   }
   public manualParseSpec() {
     if (!this.props.autoParse) {
@@ -210,8 +231,8 @@ class Editor extends React.Component<Props, {}> {
             wordWrap: 'on',
           }}
           value={this.props.value}
-          onChange={debounce(this.handleEditorChange, 700).bind(this)}
-          editorWillMount={this.editorWillMount.bind(this)}
+          onChange={debounce(this.handleEditorChange, 700)}
+          editorWillMount={this.editorWillMount}
           editorDidMount={this.editorDidMount}
         />
       </div>

--- a/src/components/input-panel/spec-editor/renderer.tsx
+++ b/src/components/input-panel/spec-editor/renderer.tsx
@@ -99,6 +99,7 @@ interface Props {
 
 const KEYCODES = {
   B: 66,
+  S: 83,
 };
 
 class Editor extends React.Component<Props, {}> {
@@ -109,8 +110,11 @@ class Editor extends React.Component<Props, {}> {
     this.editorWillMount = this.editorWillMount.bind(this);
   }
   public handleKeydown(e) {
-    if (e.keyCode === KEYCODES.B && e.ctrlKey && !this.props.autoParse) {
-      this.props.parseSpec(true);
+    if (!this.props.autoParse) {
+      if ((e.keyCode === KEYCODES.B || e.keyCode === KEYCODES.S) && (e.ctrlKey || e.metaKey)) {
+        e.preventDefault();
+        this.props.parseSpec(true);
+      }
     }
   }
   public editorDidMount(editor) {


### PR DESCRIPTION
**Add keyboard shortcuts**

- `(Ctrl || CMD) && (B || S)` for parsing.

Fixes #100.