### PR TITLE
Bug Fix: Cross-origin error

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -17,7 +17,7 @@ module.exports = (env, argv) => {
 
     devtool:
       argv.mode === "development"
-        ? "cheap-module-eval-source-map"
+        ? "cheap-module-source-map"
         : "source-map",
 
     resolve: {


### PR DESCRIPTION
Fixes #123.
Replacing `cheap-module-eval-source-map` with `cheap-module-source-map` will fix the issue but increase the rebuilding time during development.

Reference: https://webpack.js.org/configuration/devtool/#devtool and https://reactjs.org/docs/cross-origin-errors.html