### PR TITLE
feature / vega lite + gist: relative data source URLs  become absolute ones for existing files

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     init: true
     build: .
     ports:
-      - "18060:8080"
+      - "8080:8080"
     volumes:
       - "./public:/usr/src/app/public"
       - "./src:/usr/src/app/src"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     init: true
     build: .
     ports:
-      - "8080:8080"
+      - "18060:8080"
     volumes:
       - "./public:/usr/src/app/public"
       - "./src:/usr/src/app/src"

--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -81,10 +81,17 @@ class App extends React.Component<Props & { match: any; location: any }> {
 
     const spec = gistData.files[parameter.filename].content;
 
+
     if (parameter.mode === 'vega') {
       this.props.setGistVegaSpec(gistUrl, spec);
     } else if (parameter.mode === 'vega-lite') {
-      this.props.setGistVegaLiteSpec(gistUrl, spec);
+      var jo = JSON.parse(spec);
+      if ((typeof jo.data !== "undefined") && (typeof jo.data !== "undefined")) {
+        var datafile = jo.data.url;
+        if (typeof gistData.files[datafile] !== "undefined") {
+            jo.data.url = gistData.files[datafile].raw_url;
+            this.props.setGistVegaLiteSpec(gistUrl, JSON.stringify(jo));
+        }
     }
   }
 


### PR DESCRIPTION
This is about using the editor to display a vega-lite spec from a gist.

A spec that contains a Vega Lite spec with a "url"-type data source currently can be viewed in the editor only if the URL is absolute (or can be successfully resolved if the data file exists under the same hostname as the editor). This was preventing me from using relative urls in specs that are stored in gists. 

I changed the handling of gists so that if there is a relative URL as data source and the referenced file exists in the gist the data source will be updated to a absolute url.

Here's an example of such a gist:

https://gist.github.com/martinvirtel/556bc74cfdf07e194fe609da28c2aebd/#file-spec-relative-vl-json

