### PR TITLE
Add a feature to display error line number

### DIFF
--- a/src/reducers/index.ts
+++ b/src/reducers/index.ts
@@ -48,23 +48,26 @@ function parseVega(state: State, action: SetVegaExample | UpdateVegaSpec | SetGi
     };
   } catch (e) {
     const code = action.spec;
-    const pattern = /\d+/;
+    const pattern = /(position\s)(\d+)/;
     let errorMessage = e.message;
-    const charPos = errorMessage.match(pattern)[0];
+    let charPos = errorMessage.match(pattern);
 
-    if (!isNaN(charPos)) {
-      let line = 1;
-      let cursorPos = 0;
+    if (charPos !== null) {
+      charPos = charPos[2];
+      if (!isNaN(charPos)) {
+        let line = 1;
+        let cursorPos = 0;
 
-      while (cursorPos < charPos && code.indexOf('\n', cursorPos) < charPos && code.indexOf('\n', cursorPos) > -1) {
-        const newlinePos = code.indexOf('\n', cursorPos);
-        line = line + 1;
-        cursorPos = newlinePos + 1;
+        while (cursorPos < charPos && code.indexOf('\n', cursorPos) < charPos && code.indexOf('\n', cursorPos) > -1) {
+          const newlinePos = code.indexOf('\n', cursorPos);
+          line = line + 1;
+          cursorPos = newlinePos + 1;
+        }
+
+        errorMessage = `${errorMessage} and line ${line}`;
       }
-
-      errorMessage = `${errorMessage} and line ${line}`;
+      console.warn(e);
     }
-    console.warn(e);
 
     extend = {
       ...extend,

--- a/src/reducers/index.ts
+++ b/src/reducers/index.ts
@@ -47,11 +47,28 @@ function parseVega(state: State, action: SetVegaExample | UpdateVegaSpec | SetGi
       vegaSpec: spec,
     };
   } catch (e) {
+    const code = action.spec;
+    const pattern = /\d+/;
+    let errorMessage = e.message;
+    const charPos = errorMessage.match(pattern)[0];
+
+    if (!isNaN(charPos)) {
+      let line = 1;
+      let cursorPos = 0;
+
+      while (cursorPos < charPos && code.indexOf('\n', cursorPos) < charPos && code.indexOf('\n', cursorPos) > -1) {
+        const newlinePos = code.indexOf('\n', cursorPos);
+        line = line + 1;
+        cursorPos = newlinePos + 1;
+      }
+
+      errorMessage = `${errorMessage} and line ${line}`;
+    }
     console.warn(e);
 
     extend = {
       ...extend,
-      error: e.message,
+      error: errorMessage,
     };
   }
   return {


### PR DESCRIPTION
Fixes #240 

### Fix
These changes add a feature which will also display the number of line where the error exists.

### Demo
![Screenshot from 2019-03-09 19-35-32](https://user-images.githubusercontent.com/35191225/54050709-e07bf300-4205-11e9-9579-84e7f49427dc.png)

### Advantage
User can find the error more easily since the line number can be located.