### PR TITLE
Scroll Position of example portal restored.

### DIFF
--- a/src/actions/editor.ts
+++ b/src/actions/editor.ts
@@ -10,6 +10,7 @@ export const SET_GIST_VEGA_LITE_SPEC: 'SET_GIST_VEGA_LITE_SPEC' = 'SET_GIST_VEGA
 export const SET_GIST_VEGA_SPEC: 'SET_GIST_VEGA_SPEC' = 'SET_GIST_VEGA_SPEC';
 export const SET_MODE: 'SET_MODE' = 'SET_MODE';
 export const SET_MODE_ONLY: 'SET_MODE_ONLY' = 'SET_MODE_ONLY';
+export const SET_SCROLL_POSITION: 'SET_SCROLL_POSITION' = 'SET_SCROLL_POSITION';
 export const SET_RENDERER: 'SET_RENDERER' = 'SET_RENDERER';
 export const SET_VEGA_EXAMPLE: 'SET_VEGA_EXAMPLE' = 'SET_VEGA_EXAMPLE';
 export const SET_VEGA_LITE_EXAMPLE: 'SET_VEGA_LITE_EXAMPLE' = 'SET_VEGA_LITE_EXAMPLE';
@@ -25,6 +26,7 @@ export const UPDATE_VEGA_SPEC: 'UPDATE_VEGA_SPEC' = 'UPDATE_VEGA_SPEC';
 export type Action =
   | SetMode
   | SetModeOnly
+  | SetScrollPosition
   | ParseSpec
   | SetVegaExample
   | SetVegaLiteExample
@@ -60,6 +62,14 @@ export function setModeOnly(mode: Mode) {
   };
 }
 export type SetModeOnly = ReturnType<typeof setModeOnly>;
+
+export function setScrollPosition(position: number) {
+  return {
+    position,
+    type: SET_SCROLL_POSITION,
+  };
+}
+export type SetScrollPosition = ReturnType<typeof setScrollPosition>;
 
 export function parseSpec(value: boolean) {
   return {

--- a/src/components/header/index.tsx
+++ b/src/components/header/index.tsx
@@ -7,6 +7,7 @@ import Renderer from './renderer';
 const mapStateToProps = (state: State, ownProps) => {
   return {
     editorString: state.editorString,
+    lastPosition: state.lastPosition,
     manualParse: state.manualParse,
     mode: state.mode,
     vegaLiteSpec: state.vegaLiteSpec,
@@ -25,6 +26,9 @@ const mapDispatchToProps = dispatch => {
     },
     parseSpec: val => {
       dispatch(EditorActions.parseSpec(val));
+    },
+    setScrollPosition: position => {
+      dispatch(EditorActions.setScrollPosition(position));
     },
     toggleAutoParse: () => {
       dispatch(EditorActions.toggleAutoParse());

--- a/src/components/header/renderer.tsx
+++ b/src/components/header/renderer.tsx
@@ -3,6 +3,7 @@ import './index.css';
 import LZString from 'lz-string';
 import * as React from 'react';
 import Clipboard from 'react-clipboard.js';
+import ReactDOM from 'react-dom';
 import {
   Book,
   Code,
@@ -54,6 +55,7 @@ interface State {
   };
   invalidUrl: boolean;
   showVega: boolean;
+  scrollPosition: number;
 }
 
 const formatExampleName = (name: string) => {
@@ -65,7 +67,7 @@ const formatExampleName = (name: string) => {
 
 class Header extends React.Component<Props, State> {
   private refGistForm: HTMLFormElement;
-
+  private examplePortal = React.createRef<HTMLDivElement>();
   constructor(props) {
     super(props);
     this.state = {
@@ -80,6 +82,7 @@ class Header extends React.Component<Props, State> {
         url: '',
       },
       invalidUrl: false,
+      scrollPosition: 0,
       showVega: props.mode === Mode.Vega,
     };
   }
@@ -741,7 +744,18 @@ class Header extends React.Component<Props, State> {
           </PortalWithState>
         </section>
         <section className="right-section">
-          <PortalWithState closeOnEsc defaultOpen={this.props.showExample}>
+          <PortalWithState
+            closeOnEsc
+            defaultOpen={this.props.showExample}
+            onOpen={() => {
+              const node = ReactDOM.findDOMNode(this.examplePortal.current);
+              node.addEventListener('scroll', () => {
+                this.setState({
+                  scrollPosition: node.scrollTop,
+                });
+              });
+            }}
+          >
             {({ openPortal, closePortal, isOpen, portal }) => [
               <span key="0" onClick={openPortal}>
                 {examplesButton}
@@ -768,7 +782,9 @@ class Header extends React.Component<Props, State> {
                         <X />
                       </button>
                     </div>
-                    <div className="modal-body">{this.state.showVega ? vega(closePortal) : vegalite(closePortal)}</div>
+                    <div className="modal-body" ref={this.examplePortal}>
+                      {this.state.showVega ? vega(closePortal) : vegalite(closePortal)}
+                    </div>
                     <div className="modal-footer" />
                   </div>
                 </div>

--- a/src/components/header/renderer.tsx
+++ b/src/components/header/renderer.tsx
@@ -773,13 +773,21 @@ class Header extends React.Component<Props, State> {
                       <div className="button-groups">
                         <button
                           className={this.state.showVega ? 'selected' : ''}
-                          onClick={() => this.setState({ showVega: true })}
+                          onClick={() => {
+                            this.setState({ showVega: true });
+                            const node = ReactDOM.findDOMNode(this.examplePortal.current);
+                            node.scrollTop = 0;
+                          }}
                         >
                           Vega
                         </button>
                         <button
                           className={this.state.showVega ? '' : 'selected'}
-                          onClick={() => this.setState({ showVega: false })}
+                          onClick={() => {
+                            this.setState({ showVega: false });
+                            const node = ReactDOM.findDOMNode(this.examplePortal.current);
+                            node.scrollTop = 0;
+                          }}
                         >
                           Vega-Lite
                         </button>

--- a/src/components/header/renderer.tsx
+++ b/src/components/header/renderer.tsx
@@ -30,6 +30,7 @@ import { VEGA_LITE_SPECS, VEGA_SPECS } from '../../constants/specs';
 interface Props {
   editorString?: string;
   history: any;
+  lastPosition: number;
   manualParse?: boolean;
   mode: Mode;
   view: View;
@@ -40,6 +41,7 @@ interface Props {
   formatSpec: (val: any) => void;
   parseSpec: (val: any) => void;
   toggleAutoParse: () => void;
+  setScrollPosition: (position: number) => void;
 }
 
 interface State {
@@ -749,11 +751,15 @@ class Header extends React.Component<Props, State> {
             defaultOpen={this.props.showExample}
             onOpen={() => {
               const node = ReactDOM.findDOMNode(this.examplePortal.current);
+              node.scrollTop = this.props.lastPosition;
               node.addEventListener('scroll', () => {
                 this.setState({
                   scrollPosition: node.scrollTop,
                 });
               });
+            }}
+            onClose={() => {
+              this.props.setScrollPosition(this.state.scrollPosition);
             }}
           >
             {({ openPortal, closePortal, isOpen, portal }) => [

--- a/src/constants/default-state.ts
+++ b/src/constants/default-state.ts
@@ -11,6 +11,7 @@ export interface State {
   export: boolean;
   format: boolean;
   gist: string;
+  lastPosition: number;
   logs: boolean;
   manualParse: boolean;
   mode: Mode;
@@ -33,6 +34,7 @@ export const DEFAULT_STATE: State = {
   export: false,
   format: false,
   gist: null,
+  lastPosition: 0,
   logs: false,
   manualParse: false,
   mode: Mode.VegaLite,

--- a/src/reducers/index.ts
+++ b/src/reducers/index.ts
@@ -13,6 +13,7 @@ import {
   SET_MODE,
   SET_MODE_ONLY,
   SET_RENDERER,
+  SET_SCROLL_POSITION,
   SET_VEGA_EXAMPLE,
   SET_VEGA_LITE_EXAMPLE,
   SET_VIEW,
@@ -135,6 +136,11 @@ export default (state: State = DEFAULT_STATE, action: Action): State => {
       return {
         ...state,
         mode: action.mode,
+      };
+    case SET_SCROLL_POSITION:
+      return {
+        ...state,
+        lastPosition: action.position,
       };
     case PARSE_SPEC:
       return {


### PR DESCRIPTION
This PR will solve issue #247 

Steps to reproduce:
 - Open example portal
 - Scroll down to any position and select an example to view.
 - Close and reopen the portal, you will see that the scroll position is restored.

I am also attaching a screencast for reference:
![record](https://user-images.githubusercontent.com/30416891/54081813-0ce05e00-4331-11e9-9ec6-27fc38620cc7.gif)



