### PR TITLE
Fix resizing of compiled vega spec pane

### DIFF
--- a/src/actions/editor.ts
+++ b/src/actions/editor.ts
@@ -5,6 +5,7 @@ export const FORMAT_SPEC: 'FORMAT_SPEC' = 'FORMAT_SPEC';
 export const LOG_ERROR: 'LOG_ERROR' = 'LOG_ERROR';
 export const PARSE_SPEC: 'PARSE_SPEC' = 'PARSE_SPEC';
 export const SET_BASEURL: 'SET_BASEURL' = 'SET_BASEURL';
+export const SET_COMPILED_VEGA_PANE_SIZE: 'SET_COMPILED_VEGA_PANE_SIZE' = 'SET_COMPILED_VEGA_PANE_SIZE';
 export const SET_DEBUG_PANE_SIZE: 'SET_DEBUG_PANE_SIZE' = 'SET_DEBUG_PANE_SIZE';
 export const SET_GIST_VEGA_LITE_SPEC: 'SET_GIST_VEGA_LITE_SPEC' = 'SET_GIST_VEGA_LITE_SPEC';
 export const SET_GIST_VEGA_SPEC: 'SET_GIST_VEGA_SPEC' = 'SET_GIST_VEGA_SPEC';
@@ -14,9 +15,9 @@ export const SET_RENDERER: 'SET_RENDERER' = 'SET_RENDERER';
 export const SET_VEGA_EXAMPLE: 'SET_VEGA_EXAMPLE' = 'SET_VEGA_EXAMPLE';
 export const SET_VEGA_LITE_EXAMPLE: 'SET_VEGA_LITE_EXAMPLE' = 'SET_VEGA_LITE_EXAMPLE';
 export const SET_VIEW: 'SET_VIEW' = 'SET_VIEW';
-export const SHOW_COMPILED_VEGA_SPEC: 'SHOW_COMPILED_VEGA_SPEC' = 'SHOW_COMPILED_VEGA_SPEC';
 export const SHOW_LOGS: 'SHOW_LOGS' = 'SHOW_LOGS';
 export const TOGGLE_AUTO_PARSE: 'TOGGLE_AUTO_PARSE' = 'TOGGLE_AUTO_PARSE';
+export const TOGGLE_COMPILED_VEGA_SPEC: 'TOGGLE_COMPILED_VEGA_SPEC' = 'TOGGLE_COMPILED_VEGA_SPEC';
 export const TOGGLE_DEBUG_PANE: 'TOGGLE_DEBUG_PANE' = 'TOGGLE_DEBUG_PANE';
 export const UPDATE_EDITOR_STRING: 'UPDATE_EDITOR_STRING' = 'UPDATE_EDITOR_STRING';
 export const UPDATE_VEGA_LITE_SPEC: 'UPDATE_VEGA_LITE_SPEC' = 'UPDATE_VEGA_LITE_SPEC';
@@ -33,7 +34,7 @@ export type Action =
   | SetGistVegaSpec
   | SetGistVegaLiteSpec
   | ToggleAutoParse
-  | ShowCompiledVegaSpec
+  | ToggleCompiledVegaSpec
   | ToggleDebugPane
   | LogError
   | UpdateEditorString
@@ -43,7 +44,8 @@ export type Action =
   | FormatSpec
   | SetView
   | SetDebugPaneSize
-  | ShowLogs;
+  | ShowLogs
+  | SetCompiledVegaPaneSize;
 
 export function setMode(mode: Mode) {
   return {
@@ -128,12 +130,12 @@ export function toggleAutoParse() {
 }
 export type ToggleAutoParse = ReturnType<typeof toggleAutoParse>;
 
-export function showCompiledVegaSpec() {
+export function toggleCompiledVegaSpec() {
   return {
-    type: SHOW_COMPILED_VEGA_SPEC,
+    type: TOGGLE_COMPILED_VEGA_SPEC,
   };
 }
-export type ShowCompiledVegaSpec = ReturnType<typeof showCompiledVegaSpec>;
+export type ToggleCompiledVegaSpec = ReturnType<typeof toggleCompiledVegaSpec>;
 
 export function toggleDebugPane() {
   return {
@@ -213,3 +215,12 @@ export function showLogs(value: boolean) {
   };
 }
 export type ShowLogs = ReturnType<typeof showLogs>;
+
+export function setCompiledVegaPaneSize(size: number) {
+  return {
+    compiledVegaPaneSize: size,
+    type: SET_COMPILED_VEGA_PANE_SIZE,
+  };
+}
+
+export type SetCompiledVegaPaneSize = ReturnType<typeof setCompiledVegaPaneSize>;

--- a/src/components/input-panel/compiled-spec-header/index.tsx
+++ b/src/components/input-panel/compiled-spec-header/index.tsx
@@ -15,7 +15,7 @@ interface Props {
   compiledVegaSpec;
   history;
 
-  showCompiledVegaSpec: () => void;
+  toggleCompiledVegaSpec: () => void;
   updateVegaSpec: (value: any) => void;
 }
 
@@ -36,7 +36,7 @@ class CompiledSpecDisplayHeader extends React.Component<Props> {
         position: 'static',
       });
       return (
-        <div className="editor-header" style={toggleStyleUp} onClick={this.props.showCompiledVegaSpec}>
+        <div className="editor-header" style={toggleStyleUp} onClick={this.props.toggleCompiledVegaSpec}>
           <span>Compiled Vega</span>
           <ChevronDown />
           <button onClick={this.editVegaSpec} style={{ cursor: 'pointer' }}>
@@ -46,7 +46,7 @@ class CompiledSpecDisplayHeader extends React.Component<Props> {
       );
     } else {
       return (
-        <div onClick={this.props.showCompiledVegaSpec} className="editor-header" style={toggleStyle}>
+        <div onClick={this.props.toggleCompiledVegaSpec} className="editor-header" style={toggleStyle}>
           <span>Compiled Vega</span>
           <ChevronUp />
           <button onClick={this.editVegaSpec} style={{ zIndex: -1, opacity: 0, cursor: 'pointer' }}>
@@ -68,8 +68,8 @@ function mapStateToProps(state, ownProps) {
 
 const mapDispatchToProps = dispatch => {
   return {
-    showCompiledVegaSpec: () => {
-      dispatch(EditorActions.showCompiledVegaSpec());
+    toggleCompiledVegaSpec: () => {
+      dispatch(EditorActions.toggleCompiledVegaSpec());
     },
     updateVegaSpec: val => {
       dispatch(EditorActions.updateVegaSpec(val));

--- a/src/components/input-panel/index.tsx
+++ b/src/components/input-panel/index.tsx
@@ -4,6 +4,7 @@ import * as React from 'react';
 import { connect } from 'react-redux';
 import SplitPane from 'react-split-pane';
 
+import * as EditorActions from '../../actions/editor';
 import { LAYOUT, Mode } from '../../constants';
 import CompiledSpecDisplay from './compiled-spec-display';
 import CompiledSpecHeader from './compiled-spec-header';
@@ -11,10 +12,35 @@ import SpecEditor from './spec-editor';
 
 interface Props {
   compiledVegaSpec?: boolean;
+  compiledVegaPaneSize: number;
   mode?: Mode;
+
+  setCompiledVegaPaneSize: (val: any) => void;
+  toggleCompiledVegaSpec: () => void;
 }
 
 class InputPanel extends React.Component<Props> {
+  constructor(props) {
+    super(props);
+    this.handleChange = this.handleChange.bind(this);
+  }
+  public handleChange(size: number) {
+    this.props.setCompiledVegaPaneSize(size);
+    if (
+      (size > LAYOUT.MinPaneSize && !this.props.compiledVegaSpec) ||
+      (size === LAYOUT.MinPaneSize && this.props.compiledVegaSpec)
+    ) {
+      this.props.toggleCompiledVegaSpec();
+    }
+  }
+  public componentDidUpdate() {
+    const compiledVegaPane = this.refs.compiledVegaPane as any;
+    if (this.props.mode === Mode.VegaLite) {
+      if (compiledVegaPane.pane2.style.height > LAYOUT.MinPaneSize && !this.props.compiledVegaSpec) {
+        this.props.toggleCompiledVegaSpec();
+      }
+    }
+  }
   public getInnerPanes() {
     const innerPanes = [<SpecEditor key="editor" />];
     if (this.props.mode === Mode.VegaLite) {
@@ -29,25 +55,35 @@ class InputPanel extends React.Component<Props> {
   public render() {
     const innerPanes = this.getInnerPanes();
 
+    const compiledVegaPane = this.refs.compiledVegaPane as any;
+    if (compiledVegaPane) {
+      compiledVegaPane.pane2.style.height = this.props.compiledVegaSpec
+        ? (this.props.compiledVegaPaneSize || window.innerHeight * 0.4) + 'px'
+        : LAYOUT.MinPaneSize + 'px';
+    }
+
     if (this.props.mode === Mode.VegaLite) {
-      if (this.props.compiledVegaSpec) {
-        return (
-          <SplitPane
-            split="horizontal"
-            defaultSize={(window.innerHeight - LAYOUT.HeaderHeight) / innerPanes.length}
-            pane2Style={{ display: 'flex' }}
-          >
-            {innerPanes}
-          </SplitPane>
-        );
-      } else {
-        // Use the same split pane as above to prevent the creation of a new monaco instance.
-        return (
-          <SplitPane split="horizontal" primary="second" minSize={25} defaultSize={25} pane1Style={{ display: 'flex' }}>
-            {innerPanes}
-          </SplitPane>
-        );
-      }
+      return (
+        <SplitPane
+          ref="compiledVegaPane"
+          split="horizontal"
+          primary="second"
+          minSize={LAYOUT.MinPaneSize}
+          defaultSize={this.props.compiledVegaSpec ? this.props.compiledVegaPaneSize : LAYOUT.MinPaneSize}
+          onChange={this.handleChange}
+          paneStyle={{ display: 'flex' }}
+          onDragFinished={() => {
+            if (this.props.compiledVegaPaneSize === LAYOUT.MinPaneSize) {
+              this.props.setCompiledVegaPaneSize(LAYOUT.MinPaneSize + 35);
+              // LAYOUT.MinPanelSize + some amount of width that'll be visible
+              // so that the user knows that the data viewer has poped up
+              // The Ideal Amount is 35 , can be reduced or increased depending on the UI
+            }
+          }}
+        >
+          {innerPanes}
+        </SplitPane>
+      );
     } else {
       return <div className={'full-height-wrapper'}>{innerPanes}</div>;
     }
@@ -56,9 +92,24 @@ class InputPanel extends React.Component<Props> {
 
 function mapStateToProps(state, ownProps) {
   return {
+    compiledVegaPaneSize: state.compiledVegaPaneSize,
     compiledVegaSpec: state.compiledVegaSpec,
     mode: state.mode,
   };
 }
 
-export default connect(mapStateToProps)(InputPanel);
+const mapDispatchToProps = dispatch => {
+  return {
+    setCompiledVegaPaneSize: val => {
+      dispatch(EditorActions.setCompiledVegaPaneSize(val));
+    },
+    toggleCompiledVegaSpec: () => {
+      dispatch(EditorActions.toggleCompiledVegaSpec());
+    },
+  };
+};
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(InputPanel);

--- a/src/components/viz-pane/renderer.tsx
+++ b/src/components/viz-pane/renderer.tsx
@@ -1,7 +1,6 @@
 import './index.css';
 
 import * as React from 'react';
-import { ChevronDown, ChevronUp } from 'react-feather';
 import SplitPane from 'react-split-pane';
 
 import { LAYOUT, View } from '../../constants';

--- a/src/constants/default-state.ts
+++ b/src/constants/default-state.ts
@@ -4,6 +4,7 @@ import { LAYOUT, Mode, Renderer, View } from './consts';
 export interface State {
   baseURL: string;
   compiledVegaSpec: boolean;
+  compiledVegaPaneSize: number;
   debugPane: boolean;
   debugPaneSize: number;
   editorString: string;
@@ -25,6 +26,7 @@ export interface State {
 
 export const DEFAULT_STATE: State = {
   baseURL: null,
+  compiledVegaPaneSize: LAYOUT.MinPaneSize,
   compiledVegaSpec: false,
   debugPane: false,
   debugPaneSize: LAYOUT.MinPaneSize,

--- a/src/reducers/index.ts
+++ b/src/reducers/index.ts
@@ -7,6 +7,7 @@ import {
   LOG_ERROR,
   PARSE_SPEC,
   SET_BASEURL,
+  SET_COMPILED_VEGA_PANE_SIZE,
   SET_DEBUG_PANE_SIZE,
   SET_GIST_VEGA_LITE_SPEC,
   SET_GIST_VEGA_SPEC,
@@ -20,9 +21,9 @@ import {
   SetGistVegaSpec,
   SetVegaExample,
   SetVegaLiteExample,
-  SHOW_COMPILED_VEGA_SPEC,
   SHOW_LOGS,
   TOGGLE_AUTO_PARSE,
+  TOGGLE_COMPILED_VEGA_SPEC,
   TOGGLE_DEBUG_PANE,
   UPDATE_EDITOR_STRING,
   UPDATE_VEGA_LITE_SPEC,
@@ -173,7 +174,7 @@ export default (state: State = DEFAULT_STATE, action: Action): State => {
         manualParse: !state.manualParse,
         parse: state.manualParse,
       };
-    case SHOW_COMPILED_VEGA_SPEC:
+    case TOGGLE_COMPILED_VEGA_SPEC:
       return {
         ...state,
         compiledVegaSpec: !state.compiledVegaSpec,
@@ -227,6 +228,11 @@ export default (state: State = DEFAULT_STATE, action: Action): State => {
       return {
         ...state,
         logs: action.logs,
+      };
+    case SET_COMPILED_VEGA_PANE_SIZE:
+      return {
+        ...state,
+        compiledVegaPaneSize: action.compiledVegaPaneSize,
       };
     default:
       return state;


### PR DESCRIPTION
Fixes #134 

### Changes
- Fixes the problem of unnecessary white pane.
- Rename `SHOW_COMPILED_VEGA_SPEC` to `TOGGLE_COMPILED_VEGA_SPEC` because the latter conveys the meaning more appropriately.

### Demo
![demo](https://user-images.githubusercontent.com/35191225/54092651-aa30a600-43b4-11e9-9980-65b3083ec7ed.gif)
