### PR TITLE
throw an error if URL does not decompress (for issue #183)

### DIFF
--- a/src/components/input-panel/spec-editor/renderer.tsx
+++ b/src/components/input-panel/spec-editor/renderer.tsx
@@ -109,7 +109,7 @@ class Editor extends React.Component<Props, {}> {
     if (spec) {
       this.updateSpec(spec);
     } else {
-      throw new Error(`failed to decompress URL. Expected a specification, but received ${spec}`);
+      throw new Error(`Failed to decompress URL. Expected a specification, but received ${spec}`);
     }
 
     monaco.languages.json.jsonDefaults.setDiagnosticsOptions({

--- a/src/components/input-panel/spec-editor/renderer.tsx
+++ b/src/components/input-panel/spec-editor/renderer.tsx
@@ -108,6 +108,8 @@ class Editor extends React.Component<Props, {}> {
     const spec = LZString.decompressFromEncodedURIComponent(this.props.match.params.compressed);
     if (spec) {
       this.updateSpec(spec);
+    } else {
+      throw new Error(`failed to decompress URL. Expected a specification, but received ${spec}`);
     }
 
     monaco.languages.json.jsonDefaults.setDiagnosticsOptions({


### PR DESCRIPTION
As discussed in #183, if the portion of the URL containing the LZ encoded Vega specification fails to decompress then `spec` will be `null`. The editor will not update nor will it log any errors.

This PR adds a `throw` when data cannot be decompressed.