### PR TITLE
Get docker-compose working (fixes issue #255)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,14 @@
-FROM node:11-alpine
+FROM node:11
 
 # Informs Docker that the container listens on the specified port at runtime
 # https://docs.docker.com/engine/reference/builder/#expose
 EXPOSE 8080
 
+# Fetch updated list of packages
+RUN apt-get update
+
 # Install rsync as it is a dependency of ./scripts/vendor.sh
-RUN apk add rsync bash
+RUN apt-get -y install rsync
 
 # Sets the working directory for any RUN, CMD, ENTRYPOINT, COPY and ADD instructions that follow it in the Dockerfile
 # https://docs.docker.com/engine/reference/builder/#workdir
@@ -18,6 +21,9 @@ COPY package.json yarn.lock ./
 # For this project, additional files must also be copied as yarn hooks depend on them
 COPY public ./public
 COPY scripts ./scripts
+
+# Remove 'r' characters from the vendor script (otherwise it won't execute)
+RUN sed $'s/\r$//' ./scripts/vendor.sh > ./scripts/vendor.sh
 
 RUN yarn
 


### PR DESCRIPTION
**Changes:**

- Use Debian as base image as Alpine Linux does not currently work with pre-built canvas binaries

- Update packages before installing rsync (also bash package no longer needs to be installed)

- Remove '/r' characters from vendor.sh

Note that this PR does not eliminate all warnings. 

```bash
warning " > monaco-editor-webpack-plugin@1.7.0" has incorrect peer dependency "monaco-editor@^0.15.1".
```

and 

```bash
npm WARN lifecycle The node binary used for scripts is /tmp/yarn--1552313280836-0.6231136158533865/node but npm is using /usr/local/bin/node itself. Use the `--scripts-prepend-node-path` option to include the path for the node binary npm was executed with.
```

still occur, but they do not prevent Docker from working.