### PR TITLE
Refactor sharing modal

### DIFF
--- a/src/components/header/renderer.tsx
+++ b/src/components/header/renderer.tsx
@@ -82,9 +82,9 @@ class Header extends React.Component<Props, State> {
         type: props.mode,
         url: '',
       },
+      helpModalOpen: false,
       invalidFilename: false,
       invalidRevision: false,
-      helpModalOpen: false,
       invalidUrl: false,
       showVega: props.mode === Mode.Vega,
     };
@@ -144,7 +144,9 @@ class Header extends React.Component<Props, State> {
   }
 
   public handleCheck(event) {
-    this.setState({ fullscreen: event.target.checked });
+    this.setState({ fullscreen: event.target.checked }, () => {
+      this.exportURL();
+    });
   }
 
   public handleHelpModalOpen(event) {
@@ -351,9 +353,6 @@ class Header extends React.Component<Props, State> {
       setTimeout(() => {
         this.setState({ copied: false });
       }, 2500);
-    }
-    if (prevState.fullscreen !== this.state.fullscreen) {
-      this.exportURL();
     }
   }
 


### PR DESCRIPTION
Fixes #156 
`this.exportUrl()` is no longer called in `componentDidUpdate()`. Instead it is given as callback when `handleCheck` is triggered by toggling the checkbox.