### PR TITLE
Vega Docs button's alignment fixed

### DIFF
--- a/src/components/header/index.css
+++ b/src/components/header/index.css
@@ -58,7 +58,7 @@
 }
 
 .docs-link {
-  align-self: flex-end;
+  align-self: flex;
 }
 
 .modal-background {


### PR DESCRIPTION
Screenshots:

Before:
![Screenshot 2019-03-13 at 7 05 46 AM](https://user-images.githubusercontent.com/31539812/54247728-0b48ad00-4560-11e9-8f1a-e7441e5c7a1a.png)

After:
![Screenshot 2019-03-13 at 7 19 42 AM](https://user-images.githubusercontent.com/31539812/54247826-70040780-4560-11e9-8676-1858348b3655.png)
