### PR TITLE
Updates

### DIFF
--- a/src/components/data-viewer/index.css
+++ b/src/components/data-viewer/index.css
@@ -48,6 +48,7 @@
 .pagination-wrapper {
   display: inline-flex;
   vertical-align: middle;
+  margin-left: 5px;
 }
 
 .pagination {

--- a/src/components/data-viewer/index.tsx
+++ b/src/components/data-viewer/index.tsx
@@ -5,6 +5,7 @@ import Renderer from './renderer';
 
 function mapStateToProps(state: State, ownProps) {
   return {
+    debugPane: state.debugPane,
     view: state.view,
   };
 }

--- a/src/components/data-viewer/renderer.tsx
+++ b/src/components/data-viewer/renderer.tsx
@@ -11,6 +11,7 @@ import Table from '../table';
 
 interface Props {
   view?: View;
+  debugPane: boolean;
 }
 
 const initialState = {
@@ -66,9 +67,11 @@ export default class DataViewer extends React.Component<Props, State> {
 
     const data = this.props.view.data(selected) || [];
 
-    this.props.view.addDataListener(selected, () => {
-      this.forceUpdate();
-    });
+    if (this.props.debugPane) {
+      this.props.view.addDataListener(selected, () => {
+        this.forceUpdate();
+      });
+    }
 
     const pageCount = Math.ceil(data.length / ROWS_PER_PAGE);
 

--- a/src/components/data-viewer/renderer.tsx
+++ b/src/components/data-viewer/renderer.tsx
@@ -113,9 +113,6 @@ export default class DataViewer extends React.Component<Props, State> {
             clearable={false}
             searchable={false}
           />
-          <button className="data-refresh" onClick={this.handleReload}>
-            <RefreshCw /> <span>Refresh</span>
-          </button>
           <div className="pagination-wrapper">{pagination}</div>
         </div>
         <ErrorBoundary>{table}</ErrorBoundary>


### PR DESCRIPTION
Follow up for #276 

Updates: 
 - Removed refresh button.
 - Checked whether the debug panel is open or not.

Removing the listener on the closing of debugPanel will have to be a complex procedure because the debugPanel is not unmounting on hiding the panel. We will have to add and remove it on toggling the panel.

The scenario now is, the data listener is active once the panel is opened, and wont deactivate after closing the panel.

Please let me know if I will proceed with the above procedure of removing the listener on alternative toggling of panel, for this to happen, we will also need some parameters to be pushed into the redux state/ or if we want to avoid redux usage, then we should update the API, and create a api that would remove all the listeners present for the chart.

According to me, sending data to the redux store would be inefficient and hacky, creating one more API to remove all the listeners would be great.
@domoritz 