### PR TITLE
Preserve changes while switching editors

### DIFF
--- a/src/actions/editor.ts
+++ b/src/actions/editor.ts
@@ -7,6 +7,7 @@ export const PARSE_SPEC: 'PARSE_SPEC' = 'PARSE_SPEC';
 export const SET_BASEURL: 'SET_BASEURL' = 'SET_BASEURL';
 export const SET_COMPILED_VEGA_PANE_SIZE: 'SET_COMPILED_VEGA_PANE_SIZE' = 'SET_COMPILED_VEGA_PANE_SIZE';
 export const SET_DEBUG_PANE_SIZE: 'SET_DEBUG_PANE_SIZE' = 'SET_DEBUG_PANE_SIZE';
+export const SET_EDITOR_REFERENCE: 'SET_EDITOR_REFERENCE' = 'SET_EDITOR_REFERENCE';
 export const SET_GIST_VEGA_LITE_SPEC: 'SET_GIST_VEGA_LITE_SPEC' = 'SET_GIST_VEGA_LITE_SPEC';
 export const SET_GIST_VEGA_SPEC: 'SET_GIST_VEGA_SPEC' = 'SET_GIST_VEGA_SPEC';
 export const SET_MODE: 'SET_MODE' = 'SET_MODE';
@@ -23,6 +24,8 @@ export const TOGGLE_DEBUG_PANE: 'TOGGLE_DEBUG_PANE' = 'TOGGLE_DEBUG_PANE';
 export const UPDATE_EDITOR_STRING: 'UPDATE_EDITOR_STRING' = 'UPDATE_EDITOR_STRING';
 export const UPDATE_VEGA_LITE_SPEC: 'UPDATE_VEGA_LITE_SPEC' = 'UPDATE_VEGA_LITE_SPEC';
 export const UPDATE_VEGA_SPEC: 'UPDATE_VEGA_SPEC' = 'UPDATE_VEGA_SPEC';
+export const STORE_VEGA_VALUE: 'STORE_VEGA_VALUE' = 'STORE_VEGA_VALUE';
+export const STORE_VEGA_LITE_VALUE: 'STORE_VEGA_LITE_VALUE' = 'STORE_VEGA_LITE_VALUE';
 
 export type Action =
   | SetMode
@@ -47,7 +50,10 @@ export type Action =
   | SetView
   | SetDebugPaneSize
   | ShowLogs
-  | SetCompiledVegaPaneSize;
+  | SetCompiledVegaPaneSize
+  | SetEditorReference
+  | StoreVegaValue
+  | StoreVegaLiteValue;
 
 export function setMode(mode: Mode) {
   return {
@@ -234,3 +240,30 @@ export function setCompiledVegaPaneSize(size: number) {
 }
 
 export type SetCompiledVegaPaneSize = ReturnType<typeof setCompiledVegaPaneSize>;
+
+export function setEditorReference(editor: object) {
+  return {
+    editor,
+    type: SET_EDITOR_REFERENCE,
+  };
+}
+
+export type SetEditorReference = ReturnType<typeof setEditorReference>;
+
+export function storeVegaValue(vegaString: string) {
+  return {
+    type: STORE_VEGA_VALUE,
+    vegaString,
+  };
+}
+
+export type StoreVegaValue = ReturnType<typeof storeVegaValue>;
+
+export function storeVegaLiteValue(vegaLiteString: string) {
+  return {
+    type: STORE_VEGA_LITE_VALUE,
+    vegaLiteString,
+  };
+}
+
+export type StoreVegaLiteValue = ReturnType<typeof storeVegaLiteValue>;

--- a/src/components/header/index.tsx
+++ b/src/components/header/index.tsx
@@ -6,6 +6,7 @@ import Renderer from './renderer';
 
 const mapStateToProps = (state: State, ownProps) => {
   return {
+    editor: state.editor,
     editorString: state.editorString,
     lastPosition: state.lastPosition,
     manualParse: state.manualParse,
@@ -29,6 +30,12 @@ const mapDispatchToProps = dispatch => {
     },
     setScrollPosition: position => {
       dispatch(EditorActions.setScrollPosition(position));
+    },
+    storeVegaLiteValue: val => {
+      dispatch(EditorActions.storeVegaLiteValue(val));
+    },
+    storeVegaValue: val => {
+      dispatch(EditorActions.storeVegaValue(val));
     },
     toggleAutoParse: () => {
       dispatch(EditorActions.toggleAutoParse());

--- a/src/components/header/renderer.tsx
+++ b/src/components/header/renderer.tsx
@@ -1,4 +1,5 @@
 import LZString from 'lz-string';
+import Monaco from 'monaco-editor';
 import * as React from 'react';
 import Clipboard from 'react-clipboard.js';
 import ReactDOM from 'react-dom';
@@ -22,6 +23,7 @@ import {
 import { Portal, PortalWithState } from 'react-portal';
 import { withRouter } from 'react-router-dom';
 import Select from 'react-select';
+
 import { Mode, View } from '../../constants';
 import { NAMES } from '../../constants/consts';
 import { VEGA_LITE_SPECS, VEGA_SPECS } from '../../constants/specs';
@@ -29,20 +31,24 @@ import HelpModal from '../help-modal/index';
 import './index.css';
 
 interface Props {
+  editor?: object;
   editorString?: string;
   history: any;
   lastPosition: number;
   manualParse?: boolean;
   mode: Mode;
+  showExample: boolean;
   view: View;
   vegaSpec?: object;
   vegaLiteSpec?: object;
-  showExample: boolean;
+
   exportVega: (val: any) => void;
   formatSpec: (val: any) => void;
   parseSpec: (val: any) => void;
   toggleAutoParse: () => void;
   setScrollPosition: (position: number) => void;
+  storeVegaLiteValue: (val: string) => void;
+  storeVegaValue: (val: string) => void;
 }
 
 interface State {
@@ -137,6 +143,10 @@ class Header extends React.Component<Props, State> {
   }
 
   public onSelectNewVega() {
+    const editor = this.props.editor;
+    const key = 'editor';
+    const editorInstance = editor[key].getModel();
+    this.props.storeVegaLiteValue(editorInstance.getValue());
     this.props.history.push('/custom/vega');
   }
 
@@ -145,6 +155,10 @@ class Header extends React.Component<Props, State> {
   }
 
   public onSelectNewVegaLite() {
+    const editor = this.props.editor;
+    const key = 'editor';
+    const editorInstance = editor[key].getModel();
+    this.props.storeVegaValue(editorInstance.getValue());
     this.props.history.push('/custom/vega-lite');
   }
 

--- a/src/components/input-panel/spec-editor/index.tsx
+++ b/src/components/input-panel/spec-editor/index.tsx
@@ -13,6 +13,8 @@ const mapStateToProps = (state: State, ownProps) => {
     parse: state.parse,
     selectedExample: state.selectedExample,
     value: state.editorString,
+    vegaLiteValue: state.vegaLiteString,
+    vegaValue: state.vegaString,
   };
 };
 
@@ -26,6 +28,9 @@ const mapDispatchToProps = dispatch => {
     },
     parseSpec: val => {
       dispatch(EditorActions.parseSpec(val));
+    },
+    setEditorReference: editor => {
+      dispatch(EditorActions.setEditorReference(editor));
     },
     updateEditorString: val => {
       dispatch(EditorActions.updateEditorString(val));

--- a/src/components/input-panel/spec-editor/renderer.tsx
+++ b/src/components/input-panel/spec-editor/renderer.tsx
@@ -60,10 +60,13 @@ interface Props {
   mode: Mode;
   parse?: boolean;
   value?: string;
+  vegaValue?: string;
+  vegaLiteValue?: string;
 
   parseSpec: (val: any) => void;
   formatSpec: (val: any) => void;
   logError: (err: any) => void;
+  setEditorReference: (editor: object) => void;
   updateEditorString: (val: any) => void;
   updateVegaLiteSpec: (val: any) => void;
   updateVegaSpec: (val: any) => void;
@@ -154,6 +157,13 @@ class Editor extends React.Component<Props, {}> {
   }
   public componentDidMount() {
     document.addEventListener('keydown', this.handleKeydown);
+    const editor = this.refs.editor;
+    this.props.setEditorReference(editor);
+    if (this.props.mode === Mode.Vega) {
+      this.props.updateEditorString(this.props.vegaValue === '{}' ? this.props.value : this.props.vegaValue);
+    } else {
+      this.props.updateEditorString(this.props.vegaLiteValue === '{}' ? this.props.value : this.props.vegaLiteValue);
+    }
   }
   public componentWillUnmount() {
     document.removeEventListener('keydown', this.handleKeydown);
@@ -186,7 +196,7 @@ class Editor extends React.Component<Props, {}> {
         this.props.updateVegaLiteSpec(spec);
         break;
       default:
-        console.exception(`Unknown mode:  ${parsedMode}`);
+        console.exception(`Unknown mode: ${parsedMode}`);
         break;
     }
   }

--- a/src/constants/default-state.ts
+++ b/src/constants/default-state.ts
@@ -7,6 +7,7 @@ export interface State {
   compiledVegaPaneSize: number;
   debugPane: boolean;
   debugPaneSize: number;
+  editor: object;
   editorString: string;
   error: Error;
   export: boolean;
@@ -20,7 +21,9 @@ export interface State {
   renderer: Renderer;
   selectedExample: string;
   vegaLiteSpec: any;
+  vegaLiteString: string;
   vegaSpec: any;
+  vegaString: string;
   view: View;
   warningsLogger: LocalLogger;
 }
@@ -31,6 +34,7 @@ export const DEFAULT_STATE: State = {
   compiledVegaSpec: false,
   debugPane: false,
   debugPaneSize: LAYOUT.MinPaneSize,
+  editor: {},
   editorString: '{}',
   error: null,
   export: false,
@@ -44,7 +48,9 @@ export const DEFAULT_STATE: State = {
   renderer: 'canvas',
   selectedExample: null,
   vegaLiteSpec: null,
+  vegaLiteString: '{}',
   vegaSpec: {},
+  vegaString: '{}',
   view: null,
   warningsLogger: new LocalLogger(),
 };

--- a/src/reducers/index.ts
+++ b/src/reducers/index.ts
@@ -9,6 +9,7 @@ import {
   SET_BASEURL,
   SET_COMPILED_VEGA_PANE_SIZE,
   SET_DEBUG_PANE_SIZE,
+  SET_EDITOR_REFERENCE,
   SET_GIST_VEGA_LITE_SPEC,
   SET_GIST_VEGA_SPEC,
   SET_MODE,
@@ -23,6 +24,8 @@ import {
   SetVegaExample,
   SetVegaLiteExample,
   SHOW_LOGS,
+  STORE_VEGA_LITE_VALUE,
+  STORE_VEGA_VALUE,
   TOGGLE_AUTO_PARSE,
   TOGGLE_COMPILED_VEGA_SPEC,
   TOGGLE_DEBUG_PANE,
@@ -264,6 +267,21 @@ export default (state: State = DEFAULT_STATE, action: Action): State => {
       return {
         ...state,
         compiledVegaPaneSize: action.compiledVegaPaneSize,
+      };
+    case SET_EDITOR_REFERENCE:
+      return {
+        ...state,
+        editor: action.editor,
+      };
+    case STORE_VEGA_VALUE:
+      return {
+        ...state,
+        vegaString: action.vegaString,
+      };
+    case STORE_VEGA_LITE_VALUE:
+      return {
+        ...state,
+        vegaLiteString: action.vegaLiteString,
       };
     default:
       return state;


### PR DESCRIPTION
Changes are now preserved when editors are switched.
### Demo
![change](https://user-images.githubusercontent.com/35191225/54397038-078d6580-46db-11e9-82b9-781206a5d8fa.gif)

### Further improvement
It will be an enhancement if we could also restore the undo/redo history stack.

This PR doesn't resolve #12 completely but is definitely a step in a right direction.