### PR TITLE
Fixed some  examples broken

### DIFF
--- a/src/components/signal/index.tsx
+++ b/src/components/signal/index.tsx
@@ -33,7 +33,7 @@ export default class SignalRow extends React.Component<Props, State> {
   public getValue(signalKey) {
     let returnValue = '';
     const currentValue = this.props.view.signal(signalKey);
-    if (typeof currentValue === 'object') {
+    if (currentValue && typeof currentValue === 'object') {
       Object.keys(currentValue).map(value => {
         returnValue += `${value}: ${currentValue[value]}, `;
       });


### PR DESCRIPTION
So this is an interesting bug,
To render the table we are mapping over the Object.keys and before that we are checking if currentValue === object .
This is interesting because we are getting a null value and type of null is actually an Object (this is a js bug duh!) so Object.key(null) is an error . 
An easy fix is to check if the value is not falsy.