### PR TITLE
Remove warning generated due to rendering of kbd tags

### DIFF
--- a/src/components/help-modal/index.tsx
+++ b/src/components/help-modal/index.tsx
@@ -13,11 +13,14 @@ const pjson = require('../../../package.json');
 // 3. Map over shorcuts and render os specific
 // 4. Get shortcut, split it, and map over it to render
 // 5. To add shortcuts go to utils/keyboardShortcuts.ts, changes will be reflected here
+
 const keyBoardShortcuts = shortcuts.map((shortcut, i) => {
   return (
     <li key={i}>
-      {(isMac() ? shortcut.mac : shortcut.windows).split(' ').map(key => (key === '+' ? '+' : <kbd>{key}</kbd>))}:{' '}
-      {shortcut.text}
+      {(isMac() ? shortcut.mac : shortcut.windows)
+        .split(' ')
+        .map(key => (key === '+' ? '+' : <kbd key={`${key}${i}`}>{key}</kbd>))}
+      : {shortcut.text}
     </li>
   );
 });


### PR DESCRIPTION
Fixes this warning

![Screenshot from 2019-03-24 17-28-16](https://user-images.githubusercontent.com/35191225/54879042-9d06c300-4e5a-11e9-8cca-7c44ddf663e1.png)

Just passed a `key` prop to `<kbd>` tags.