### PR TITLE
Add signal listeners in componentDidUpdate

### DIFF
--- a/src/components/signal-viewer/signalRow.tsx
+++ b/src/components/signal-viewer/signalRow.tsx
@@ -20,6 +20,15 @@ export default class SignalRow extends React.Component<Props, State> {
     };
     this.signalHandler = this.signalHandler.bind(this);
   }
+  public componentDidUpdate(prevProps) {
+    if (prevProps.view !== this.props.view) {
+      prevProps.view.removeSignalListener(prevProps.signal, this.signalHandler);
+      this.props.view.addSignalListener(this.props.signal, this.signalHandler);
+      this.setState({
+        signalValue: this.props.view.signal(this.props.signal),
+      });
+    }
+  }
   public componentDidMount() {
     this.props.view.addSignalListener(this.props.signal, this.signalHandler);
   }


### PR DESCRIPTION
Signal listeners were added in componentDidUpdate because if we leave the signal tab opened, and then edit the spec, the signal listeners were added to `prevProps` which caused dysfunction in real-time change of signal values in the table afterwards. And since the component is already mounted, new signal listeners weren't added. So `componentDidUpdate` just adds the signal listener to a new set of `props`.