### PR TITLE
Fix height of debug pane header when resizing vertically

### DIFF
--- a/src/components/viz-pane/index.css
+++ b/src/components/viz-pane/index.css
@@ -20,7 +20,7 @@
 .debug-pane-header {
   position: relative;
   width: 100%;
-  height: 30px;
+  min-height: 25px;
   display: flex;
   align-items: center;
   justify-content: space-between;


### PR DESCRIPTION
Fixes #321 
![Screenshot from 2019-03-26 02-09-40](https://user-images.githubusercontent.com/35191225/54952549-3c67ab00-4f6c-11e9-82cf-c3c88b59b255.png)
