### PR TITLE
[WIP] Fix resizing of compiled spec pane

### DIFF
--- a/src/actions/editor.ts
+++ b/src/actions/editor.ts
@@ -7,6 +7,7 @@ export const PARSE_SPEC: 'PARSE_SPEC' = 'PARSE_SPEC';
 export const SET_BASEURL: 'SET_BASEURL' = 'SET_BASEURL';
 export const SET_COMPILED_VEGA_PANE_SIZE: 'SET_COMPILED_VEGA_PANE_SIZE' = 'SET_COMPILED_VEGA_PANE_SIZE';
 export const SET_DEBUG_PANE_SIZE: 'SET_DEBUG_PANE_SIZE' = 'SET_DEBUG_PANE_SIZE';
+export const SET_SPEC_EDIOTR_REFERENCE: 'SET_SPEC_EDIOTR_REFERENCE' = 'SET_SPEC_EDIOTR_REFERENCE';
 export const SET_GIST_VEGA_LITE_SPEC: 'SET_GIST_VEGA_LITE_SPEC' = 'SET_GIST_VEGA_LITE_SPEC';
 export const SET_GIST_VEGA_SPEC: 'SET_GIST_VEGA_SPEC' = 'SET_GIST_VEGA_SPEC';
 export const SET_MODE: 'SET_MODE' = 'SET_MODE';
@@ -49,7 +50,8 @@ export type Action =
   | SetView
   | SetDebugPaneSize
   | ShowLogs
-  | SetCompiledVegaPaneSize;
+  | SetCompiledVegaPaneSize
+  | SetSpecEditorReference;
 
 export function setMode(mode: Mode) {
   return {
@@ -245,3 +247,12 @@ export function toggleNavbar(value: string) {
 }
 
 export type ToggleNavbar = ReturnType<typeof toggleNavbar>;
+
+export function setSpecEditorReference(value: any) {
+  return {
+    specEditorReference: value,
+    type: SET_SPEC_EDIOTR_REFERENCE,
+  };
+}
+
+export type SetSpecEditorReference = ReturnType<typeof setSpecEditorReference>;

--- a/src/components/input-panel/index.tsx
+++ b/src/components/input-panel/index.tsx
@@ -7,8 +7,9 @@ import { LAYOUT, Mode } from '../../constants';
 import { State } from '../../constants/default-state';
 import CompiledSpecDisplay from './compiled-spec-display';
 import CompiledSpecHeader from './compiled-spec-header';
-import './index.css';
 import SpecEditor from './spec-editor';
+
+import './index.css';
 
 type Props = ReturnType<typeof mapStateToProps> & ReturnType<typeof mapDispatchToProps>;
 
@@ -30,6 +31,9 @@ class InputPanel extends React.Component<Props> {
     if (this.props.mode === Mode.VegaLite) {
       if (this.props.compiledVegaPaneSize === LAYOUT.MinPaneSize) {
         this.props.setCompiledVegaPaneSize((window.innerHeight - LAYOUT.HeaderHeight) * 0.3);
+      }
+      if (this.props.specEditorReference !== null) {
+        this.props.specEditorReference['editor' as any].layout({});
       }
     }
   }
@@ -86,6 +90,7 @@ function mapStateToProps(state: State, ownProps) {
     compiledVegaPaneSize: state.compiledVegaPaneSize,
     compiledVegaSpec: state.compiledVegaSpec,
     mode: state.mode,
+    specEditorReference: state.specEditorReference,
   };
 }
 

--- a/src/components/input-panel/spec-editor/index.tsx
+++ b/src/components/input-panel/spec-editor/index.tsx
@@ -22,6 +22,7 @@ export function mapDispatchToProps(dispatch: Dispatch<EditorActions.Action>) {
       formatSpec: EditorActions.formatSpec,
       logError: EditorActions.logError,
       parseSpec: EditorActions.parseSpec,
+      setSpecEditorReference: EditorActions.setSpecEditorReference,
       updateEditorString: EditorActions.updateEditorString,
       updateVegaLiteSpec: EditorActions.updateVegaLiteSpec,
       updateVegaSpec: EditorActions.updateVegaSpec,

--- a/src/components/input-panel/spec-editor/renderer.tsx
+++ b/src/components/input-panel/spec-editor/renderer.tsx
@@ -119,6 +119,7 @@ class Editor extends React.Component<Props, {}> {
   }
   public componentDidMount() {
     document.addEventListener('keydown', this.handleKeydown);
+    this.props.setSpecEditorReference(this.refs.editor);
   }
   public componentWillUnmount() {
     document.removeEventListener('keydown', this.handleKeydown);

--- a/src/constants/default-state.ts
+++ b/src/constants/default-state.ts
@@ -22,6 +22,7 @@ export interface State {
   parse: boolean;
   renderer: Renderer;
   selectedExample: string;
+  specEditorReference: any;
   vegaLiteSpec: VlSpec;
   vegaSpec: Spec;
   view: View;
@@ -48,6 +49,7 @@ export const DEFAULT_STATE: State = {
   parse: false,
   renderer: 'canvas',
   selectedExample: null,
+  specEditorReference: null,
   vegaLiteSpec: null,
   vegaSpec: {},
   view: null,

--- a/src/reducers/index.ts
+++ b/src/reducers/index.ts
@@ -15,6 +15,7 @@ import {
   SET_MODE_ONLY,
   SET_RENDERER,
   SET_SCROLL_POSITION,
+  SET_SPEC_EDIOTR_REFERENCE,
   SET_VEGA_EXAMPLE,
   SET_VEGA_LITE_EXAMPLE,
   SET_VIEW,
@@ -275,6 +276,11 @@ export default (state: State = DEFAULT_STATE, action: Action): State => {
       return {
         ...state,
         navItem: action.navItem,
+      };
+    case SET_SPEC_EDIOTR_REFERENCE:
+      return {
+        ...state,
+        specEditorReference: action.specEditorReference,
       };
     default:
       return state;


### PR DESCRIPTION
Addresses #316 

- [x] Fix the jamming of compiled spec pane header when the pane's size was increased.
- [ ] Fix flickering of the spec editor.

![bug](https://user-images.githubusercontent.com/35191225/54999228-ca3ba880-4ff5-11e9-8ef0-3ae7add94574.gif)

I used a function [`editor.layout()`](https://microsoft.github.io/monaco-editor/api/interfaces/monaco.editor.istandalonecodeeditor.html#layout) to resolve this bug.

Other possible solution could be a minor CSS bug because the spec-editor could easily expand but can't shrink. If anyone has any better solution for this, please provide suggestions.