### PR TITLE
Serialize function to prevent crashing

### DIFF
--- a/src/components/signal-viewer/signalRow.tsx
+++ b/src/components/signal-viewer/signalRow.tsx
@@ -39,8 +39,14 @@ export default class SignalRow extends React.Component<Props, State> {
     let tooLong = false;
     let formatted = '';
     if (!isDate(this.state.signalValue)) {
-      tooLong = formatValueLong(this.state.signalValue).tooLong;
-      formatted = formatValueLong(this.state.signalValue).formatted;
+      const formatValue = formatValueLong(this.state.signalValue);
+      if (formatValue !== undefined) {
+        tooLong = formatValue.tooLong;
+        formatted = formatValue.formatted;
+      } else {
+        tooLong = false;
+        formatted = 'undefined';
+      }
     } else {
       tooLong = false;
       formatted = new Date(this.state.signalValue).toUTCString();

--- a/src/components/table/renderer.tsx
+++ b/src/components/table/renderer.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { isArray, isDate, isObject } from 'vega';
+import { isDate, isFunction } from 'vega';
 import { stringify } from 'vega-tooltip';
 import './index.css';
 
@@ -53,7 +53,8 @@ export default class Table extends React.PureComponent<Props> {
 }
 
 export function formatValueLong(value: any) {
-  const formatted = value === undefined ? 'undefined' : stringify(value, MAX_DEPTH);
+  const formatted =
+    value === undefined ? 'undefined' : isFunction(value) ? value.toString() : stringify(value, MAX_DEPTH);
   if (formatted.length > MAX_LENGTH) {
     return { formatted: null, tooLong: true };
   }


### PR DESCRIPTION
Fixes #327 
- Serialise function
- Handle crashing if `undefined` is returned from `formatValueLong`