### PR TITLE
Add spacing between sharing buttons

### DIFF
--- a/src/components/header/share-modal/index.css
+++ b/src/components/header/share-modal/index.css
@@ -29,7 +29,7 @@
   cursor: pointer;
   user-select: none;
   vertical-align: middle;
-  margin: 30px 0;
+  margin: 30px 10px 30px 0;
 }
 
 .share-button svg {


### PR DESCRIPTION
Fixes #339 

![share-modal](https://user-images.githubusercontent.com/35191225/56453121-989ad080-635a-11e9-9194-06a73d41328f.png)

This one line change adds `10px` right margin to both the buttons.