### PR TITLE
Correct type of error

### DIFF
--- a/src/components/error-boundary/renderer.tsx
+++ b/src/components/error-boundary/renderer.tsx
@@ -12,7 +12,7 @@ export default class ErrorBoundary extends React.PureComponent<Props> {
     if (this.props.error) {
       return (
         <div id="error-indicator" onClick={e => this.props.toggleDebugPane()}>
-          {this.props.error}
+          {this.props.error.message}
         </div>
       );
     }

--- a/src/components/error-pane/renderer.tsx
+++ b/src/components/error-pane/renderer.tsx
@@ -12,7 +12,7 @@ export default class ErrorPane extends React.PureComponent<Props> {
       list.push(
         <li key={0}>
           <span className="error">[Error] </span>
-          {this.props.error}
+          {this.props.error.message}
         </li>
       );
     }

--- a/src/reducers/index.ts
+++ b/src/reducers/index.ts
@@ -63,7 +63,11 @@ function errorLine(code: string, error: string) {
   }
 }
 
-function parseVega(state: State, action: SetVegaExample | UpdateVegaSpec | SetGistVegaSpec, extend = {}) {
+function parseVega(
+  state: State,
+  action: SetVegaExample | UpdateVegaSpec | SetGistVegaSpec,
+  extend: Partial<State> = {}
+) {
   const currLogger = new LocalLogger();
 
   try {
@@ -81,7 +85,7 @@ function parseVega(state: State, action: SetVegaExample | UpdateVegaSpec | SetGi
 
     extend = {
       ...extend,
-      error: errorMessage,
+      error: new Error(errorMessage),
     };
   }
   const logger = { ...currLogger };
@@ -104,7 +108,7 @@ function parseVega(state: State, action: SetVegaExample | UpdateVegaSpec | SetGi
 function parseVegaLite(
   state: State,
   action: SetVegaLiteExample | UpdateVegaLiteSpec | SetGistVegaLiteSpec,
-  extend = {}
+  extend: Partial<State> = {}
 ) {
   const currLogger = new LocalLogger();
 
@@ -126,7 +130,7 @@ function parseVegaLite(
 
     extend = {
       ...extend,
-      error: errorMessage,
+      error: new Error(errorMessage),
     };
   }
   const logger = { ...currLogger };


### PR DESCRIPTION
We previously assigned a string to the `error` property, which is supposed to be an `Error`.