### PR TITLE
Modify condition to check if user has gists

### DIFF
--- a/src/components/header/gist-modal/renderer.tsx
+++ b/src/components/header/gist-modal/renderer.tsx
@@ -361,7 +361,7 @@ class GistModal extends React.PureComponent<Props, State> {
             {this.props.isAuthenticated ? (
               this.state.loaded ? (
                 <>
-                  {this.state.personalGist !== [] ? (
+                  {this.state.personalGist.length > 0 ? (
                     <>
                       <div className="privacy-toggle">
                         <input


### PR DESCRIPTION
### Fun fact
Even if `this.state.personalGist` is an empty array, `[] !== []` since they both reference a different memory location.

Therefore, it is better to check the length of `this.state.personalGist`. 