### PR TITLE
Fix mode switch bug

### DIFF
--- a/src/components/header/renderer.tsx
+++ b/src/components/header/renderer.tsx
@@ -107,6 +107,10 @@ class Header extends React.PureComponent<Props, State> {
     this.props.history.push(`/examples/vega/${name}`);
   }
 
+  public onSelectNewVega() {
+    this.props.history.push('/');
+  }
+
   public onSelectVegaLite(name) {
     this.props.history.push(`/examples/vega-lite/${name}`);
   }
@@ -116,7 +120,9 @@ class Header extends React.PureComponent<Props, State> {
   }
 
   public onSwitchMode(option) {
-    option.value === Mode.Vega ? this.props.updateVegaSpec(stringify(this.props.vegaSpec)) : this.onSelectNewVegaLite();
+    option.value === Mode.Vega
+      ? this.props.updateVegaSpec(stringify(this.props.vegaSpec)) && this.onSelectNewVega()
+      : this.onSelectNewVegaLite();
     this.props.clearConfig();
   }
 

--- a/src/components/header/renderer.tsx
+++ b/src/components/header/renderer.tsx
@@ -121,7 +121,8 @@ class Header extends React.PureComponent<Props, State> {
 
   public onSwitchMode(option) {
     if (option.value === Mode.Vega) {
-      this.props.updateVegaSpec(stringify(this.props.vegaSpec)) && this.onSelectNewVega();
+      this.props.updateVegaSpec(stringify(this.props.vegaSpec));
+      this.onSelectNewVega();
     } else {
       this.onSelectNewVegaLite();
     }

--- a/src/components/header/renderer.tsx
+++ b/src/components/header/renderer.tsx
@@ -120,9 +120,11 @@ class Header extends React.PureComponent<Props, State> {
   }
 
   public onSwitchMode(option) {
-    option.value === Mode.Vega
-      ? this.props.updateVegaSpec(stringify(this.props.vegaSpec)) && this.onSelectNewVega()
-      : this.onSelectNewVegaLite();
+    if (option.value === Mode.Vega) {
+      this.props.updateVegaSpec(stringify(this.props.vegaSpec)) && this.onSelectNewVega();
+    } else {
+      this.onSelectNewVegaLite();
+    }
     this.props.clearConfig();
   }
 

--- a/src/components/header/renderer.tsx
+++ b/src/components/header/renderer.tsx
@@ -108,7 +108,7 @@ class Header extends React.PureComponent<Props, State> {
   }
 
   public onSelectNewVega() {
-    this.props.history.push('/');
+    this.props.history.push('/custom/vega');
   }
 
   public onSelectVegaLite(name) {


### PR DESCRIPTION
Vega and Vega-light modes were not switching repeatedly because the hash history was not able to push the same path.
Changing the route when the mode is switched to vega solved the issue.