### PR TITLE
Lazy loading for header components

### DIFF
--- a/src/components/header/renderer.tsx
+++ b/src/components/header/renderer.tsx
@@ -10,8 +10,8 @@ import {BACKEND_URL, COOKIE_NAME, KEYCODES, Mode} from '../../constants';
 import {NAMES} from '../../constants/consts';
 import {VEGA_LITE_SPECS, VEGA_SPECS} from '../../constants/specs';
 import getCookie from '../../utils/getCookie';
-import ExportModal from './export-modal/index';
-import GistModal from './gist-modal/index';
+const ExportModal = React.lazy(() => import('./export-modal/index'));
+const GistModal = React.lazy(() => import('./gist-modal/index'));
 import HelpModal from './help-modal/index';
 import './index.css';
 const ShareModal = React.lazy(() => import('./share-modal/index'));
@@ -381,8 +381,18 @@ class Header extends React.PureComponent<Props, State> {
       </div>
     );
 
-    const gist = closePortal => <GistModal closePortal={() => closePortal()} />;
-    const exportContent = <ExportModal />;
+    const gist = closePortal => {
+      return (
+        <React.Suspense fallback={<React.Fragment></React.Fragment>}>
+          <GistModal closePortal={() => closePortal()} />
+        </React.Suspense>
+      );
+    };
+    const exportContent = (
+      <React.Suspense fallback={<React.Fragment></React.Fragment>}>
+        <ExportModal />
+      </React.Suspense>
+    );
     const shareContent = (
       <React.Suspense fallback={<React.Fragment></React.Fragment>}>
         <ShareModal />

--- a/src/components/header/renderer.tsx
+++ b/src/components/header/renderer.tsx
@@ -14,7 +14,7 @@ import ExportModal from './export-modal/index';
 import GistModal from './gist-modal/index';
 import HelpModal from './help-modal/index';
 import './index.css';
-import ShareModal from './share-modal/index';
+const ShareModal = React.lazy(() => import('./share-modal/index'));
 
 type Props = ReturnType<typeof mapStateToProps> &
   ReturnType<typeof mapDispatchToProps> & {
@@ -383,7 +383,11 @@ class Header extends React.PureComponent<Props, State> {
 
     const gist = closePortal => <GistModal closePortal={() => closePortal()} />;
     const exportContent = <ExportModal />;
-    const shareContent = <ShareModal />;
+    const shareContent = (
+      <React.Suspense fallback={<React.Fragment></React.Fragment>}>
+        <ShareModal />
+      </React.Suspense>
+    );
 
     return (
       <div className="header">

--- a/src/components/header/renderer.tsx
+++ b/src/components/header/renderer.tsx
@@ -12,7 +12,7 @@ import {VEGA_LITE_SPECS, VEGA_SPECS} from '../../constants/specs';
 import getCookie from '../../utils/getCookie';
 const ExportModal = React.lazy(() => import('./export-modal/index'));
 const GistModal = React.lazy(() => import('./gist-modal/index'));
-import HelpModal from './help-modal/index';
+const HelpModal = React.lazy(() => import('./help-modal/index'));
 import './index.css';
 const ShareModal = React.lazy(() => import('./share-modal/index'));
 
@@ -548,7 +548,9 @@ class Header extends React.PureComponent<Props, State> {
                         </button>
                       </div>
                       <div className="modal-body">
-                        <HelpModal />
+                        <React.Suspense fallback={<React.Fragment></React.Fragment>}>
+                          <HelpModal />
+                        </React.Suspense>
                       </div>
                     </div>
                   </div>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,11 @@
 {
   "compilerOptions": {
     "target": "es6",
-    "module": "es2015",
-    "lib": ["esnext", "dom"],
+    "module": "esnext",
+    "lib": [
+      "esnext",
+      "dom"
+    ],
     "moduleResolution": "node",
     "declaration": false,
     "noImplicitAny": false,
@@ -14,8 +17,12 @@
     "allowSyntheticDefaultImports": true,
     "importHelpers": true
   },
-  "files": ["src/index.tsx"],
-  "include": ["node_modules/vega-lite/typings/*.d.ts"],
+  "files": [
+    "src/index.tsx"
+  ],
+  "include": [
+    "node_modules/vega-lite/typings/*.d.ts"
+  ],
   "awesomeTypescriptLoaderOptions": {
     "useCache": true,
     "forceIsolatedModules": true,


### PR DESCRIPTION
Lazy loading code - #443 
- Changed module to esnext in tsconfig(for lazy loading to work with typescript)

- Added lazy loading to export, share, gist, help components.
