### PR TITLE
feat: add resize handle for responsive charts

### DIFF
--- a/src/components/renderer/index.css
+++ b/src/components/renderer/index.css
@@ -3,6 +3,7 @@
   padding: 10px;
   display: inline-block;
   margin-right: 10px;
+  position: relative;
 }
 
 .chart .vega-bindings {
@@ -41,11 +42,16 @@
   overflow: auto;
   display: flex;
   align-items: center;
+  background: white;
   z-index: 15;
 }
 
 .fullscreen-chart > div {
   margin: auto;
+}
+
+.fullscreen-chart .chart {
+  box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
 }
 
 .fullscreen-open {
@@ -63,4 +69,21 @@
   right: 20px;
   font-size: 1.1em;
   z-index: 1000;
+}
+
+.chart-resize-handle {
+  width: 10px;
+  height: 10px;
+  right: 0;
+  bottom: 0;
+  cursor: nwse-resize;
+  position: absolute;
+}
+
+.chart-resize-handle svg {
+  display: block;
+}
+
+.chart-resize-handle svg path {
+  stroke: #ddd;
 }

--- a/src/components/renderer/renderer.tsx
+++ b/src/components/renderer/renderer.tsx
@@ -78,14 +78,12 @@ class Editor extends React.PureComponent<Props, State> {
     return {responsiveWidth, responsiveHeight};
   }
 
-  public handleResizeMouseDown(e: React.MouseEvent) {
-    const x0 = e.pageX;
-    const y0 = e.pageY;
+  public handleResizeMouseDown(eDown: React.MouseEvent) {
+    const {pageX: x0, pageY: y0} = eDown;
     const {width: width0, height: height0} = this.state;
     const {responsiveWidth, responsiveHeight} = this.isResponsive();
     const onMove = (eMove: MouseEvent) => {
-      const x1 = eMove.pageX;
-      const y1 = eMove.pageY;
+      const {pageX: x1, pageY: y1} = eMove;
       const factor = this.state.fullscreen ? 2 : 1;
       this.setState(
         {

--- a/src/components/renderer/renderer.tsx
+++ b/src/components/renderer/renderer.tsx
@@ -65,6 +65,7 @@ class Editor extends React.PureComponent<Props, State> {
     const spec = this.props.vegaSpec;
     let responsiveWidth = false;
     let responsiveHeight = false;
+    // Check for signals
     if (spec.signals) {
       for (const signal of spec.signals) {
         if (signal.name == 'width' && (signal as vega.InitSignal).init.indexOf('containerSize') >= 0) {
@@ -79,11 +80,16 @@ class Editor extends React.PureComponent<Props, State> {
   }
 
   public handleResizeMouseDown(eDown: React.MouseEvent) {
-    const {pageX: x0, pageY: y0} = eDown;
-    const {width: width0, height: height0} = this.state;
     const {responsiveWidth, responsiveHeight} = this.isResponsive();
+    // Record initial mouse position and view size
+    const x0 = eDown.pageX;
+    const y0 = eDown.pageY;
+    const width0 = this.state.width;
+    const height0 = this.state.height;
+    // Update size on window.mousemove
     const onMove = (eMove: MouseEvent) => {
-      const {pageX: x1, pageY: y1} = eMove;
+      const x1 = eMove.pageX;
+      const y1 = eMove.pageY;
       const factor = this.state.fullscreen ? 2 : 1;
       this.setState(
         {
@@ -96,10 +102,12 @@ class Editor extends React.PureComponent<Props, State> {
         }
       );
     };
+    // Remove listeners on window.mouseup
     const onUp = () => {
       window.removeEventListener('mousemove', onMove);
       window.removeEventListener('mouseup', onUp);
     };
+    // Add listeners
     window.addEventListener('mousemove', onMove);
     window.addEventListener('mouseup', onUp);
   }
@@ -239,9 +247,11 @@ class Editor extends React.PureComponent<Props, State> {
     this.unlisten();
   }
 
+  // Render resize handle for responsive charts
   public renderResizeHandle() {
     const {responsiveWidth, responsiveHeight} = this.isResponsive();
     if (responsiveWidth || responsiveHeight) {
+      // The handle is defined as a inline SVG
       return (
         <div className="chart-resize-handle" onMouseDown={this.handleResizeMouseDown.bind(this)}>
           <svg width="10" height="10">
@@ -254,6 +264,7 @@ class Editor extends React.PureComponent<Props, State> {
 
   public render() {
     const {responsiveWidth, responsiveHeight} = this.isResponsive();
+    // Determine chart element style based on responsiveness
     const chartStyle =
       responsiveWidth || responsiveHeight
         ? {

--- a/src/components/renderer/renderer.tsx
+++ b/src/components/renderer/renderer.tsx
@@ -1,6 +1,6 @@
 import {UnregisterCallback} from 'history';
 import * as React from 'react';
-import {Edit3, Maximize} from 'react-feather';
+import {Maximize} from 'react-feather';
 import {Portal} from 'react-portal';
 import {RouteComponentProps, withRouter} from 'react-router-dom';
 import ReactTooltip from 'react-tooltip';
@@ -62,11 +62,11 @@ class Editor extends React.PureComponent<Props, State> {
     let w = false;
     let h = false;
     if (spec.signals && spec.signals instanceof Array) {
-      for (const signal of spec.signals as any) {
-        if (signal.name == 'width' && signal.init == 'containerSize()[0]') {
+      for (const signal of spec.signals) {
+        if (signal.name == 'width' && (signal as vega.InitSignal).init == 'containerSize()[0]') {
           w = true;
         }
-        if (signal.name == 'height' && signal.init == 'containerSize()[1]') {
+        if (signal.name == 'height' && (signal as vega.InitSignal).init == 'containerSize()[1]') {
           h = true;
         }
       }

--- a/src/components/renderer/renderer.tsx
+++ b/src/components/renderer/renderer.tsx
@@ -57,7 +57,11 @@ class Editor extends React.PureComponent<Props, State> {
     }
   }
 
-  public isResponsive() {
+  // Determine if the Vega spec has responsive width/height.
+  // Current criteria:
+  // - Width(height) is defined as a signal
+  // - The init property of the signal uses "containerSize".
+  public isResponsive(): {responsiveWidth: boolean; responsiveHeight: boolean} {
     const spec = this.props.vegaSpec;
     let responsiveWidth = false;
     let responsiveHeight = false;


### PR DESCRIPTION
Add a resize handle for responsive charts. The resize handle appears when the chart is supposed to be responsive, precisely:
- Either width or height is defined as a signal, and
- the signal uses `containerSize()[0]` or `containerSize()[1]` as its `init`.