### PR TITLE
Unhide checkbox when there are no gists

### DIFF
--- a/src/components/header/gist-modal/renderer.tsx
+++ b/src/components/header/gist-modal/renderer.tsx
@@ -386,18 +386,18 @@ class GistModal extends React.PureComponent<Props, State> {
             {this.props.isAuthenticated ? (
               this.state.loaded ? (
                 <>
+                  <div className="privacy-toggle">
+                    <input
+                      type="checkbox"
+                      name="privacy"
+                      id="privacy"
+                      checked={this.props.private === GistPrivacy.ALL}
+                      onChange={this.props.toggleGistPrivacy}
+                    />
+                    <label htmlFor="privacy">Show private gists</label>
+                  </div>
                   {this.state.personalGist.length > 0 ? (
                     <>
-                      <div className="privacy-toggle">
-                        <input
-                          type="checkbox"
-                          name="privacy"
-                          id="privacy"
-                          checked={this.props.private === GistPrivacy.ALL}
-                          onChange={this.props.toggleGistPrivacy}
-                        />
-                        <label htmlFor="privacy">Show private gists</label>
-                      </div>
                       {Object.keys(this.state.pages).length > 1 && (
                         <ReactPaginate
                           previousLabel={'<'}


### PR DESCRIPTION
This was required if someone only has private gists compatible with vega, and on unchecking the box, the box disappears and shows "You have no Vega or Vega-Lite compatible gists.". Hence, there was no way we could go back except changing the state from `localStorage`.