### PR TITLE
Rearrange and clean up Dockerfile commands for it to work on windows

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,22 +10,18 @@ RUN apt-get update && apt-get upgrade -y
 # Install rsync as it is a dependency of ./scripts/vendor.sh
 RUN apt-get -y install rsync
 
+# Install dos2unix to remove 'r' characters from scripts
+RUN apt-get install dos2unix
+
 # Sets the working directory for any RUN, CMD, ENTRYPOINT, COPY and ADD instructions that follow it in the Dockerfile
 # https://docs.docker.com/engine/reference/builder/#workdir
 WORKDIR /usr/src/app
 
-# Copies the package.json and yarn.lock files first to ensure the cache is only invalidated when these files change
-# https://nodejs.org/en/docs/guides/nodejs-docker-webapp/#creating-a-dockerfile
-COPY package.json yarn.lock ./
-
-# For this project, additional files must also be copied as yarn hooks depend on them
-COPY scripts ./scripts
-
-# Remove 'r' characters from the vendor script (otherwise it won't execute)
-RUN sed $'s/\r$//' ./scripts/vendor.sh > ./scripts/vendor.sh
-
-# Copy remaining files
+# Copy all files
 COPY . .
+
+# Remove 'r' characters from the scripts (otherwise it won't execute)
+RUN dos2unix ./scripts/generate-example-images.sh ./scripts/vendor.sh ./scripts/version.sh
 
 # Run Yarn
 RUN yarn


### PR DESCRIPTION
COPY overwites the modified scripts files so I moved the removal of 'r' characters AFTER the copy