### PR TITLE
feat: added warning for version mismatch

### DIFF
--- a/src/reducers/index.ts
+++ b/src/reducers/index.ts
@@ -1,5 +1,7 @@
 import stringify from 'json-stringify-pretty-compact';
-import {mergeConfig} from 'vega';
+import {mergeConfig, version} from 'vega';
+import {satisfies} from 'semver';
+import schemaParser from 'vega-schema-url-parser';
 import * as vegaLite from 'vega-lite';
 import {Config} from 'vega-lite/src/config';
 import {TopLevelSpec} from 'vega-lite/src/spec';
@@ -153,6 +155,10 @@ function parseVega(
 
   try {
     const spec = JSON.parse(action.spec);
+    const parsed = schemaParser(spec.$schema);
+
+    if (!satisfies(version, `^${parsed.version.slice(1)}`))
+      currLogger.warn(`The input spec uses Vega ${parsed.version}, but the current version of Vega is v${version}.`);
 
     validateVega(spec, currLogger);
 
@@ -215,6 +221,14 @@ function parseVegaLite(
       config,
       logger: currLogger
     };
+
+    const parsed = schemaParser(vegaLiteSpec.$schema);
+
+    if (!satisfies(vegaLite.version, `^${parsed.version.slice(1)}`))
+      currLogger.warn(
+        `The input spec uses Vega-Lite ${parsed.version}, but the current version of Vega-Lite is v${vegaLite.version}.`
+      );
+
     validateVegaLite(vegaLiteSpec, currLogger);
 
     const vegaSpec = spec !== '{}' ? vegaLite.compile(vegaLiteSpec, options).spec : {};

--- a/src/reducers/index.ts
+++ b/src/reducers/index.ts
@@ -157,6 +157,13 @@ function parseVega(
     const spec = JSON.parse(action.spec);
     const parsed = schemaParser(spec.$schema);
 
+    const parsedVersionArray = parsed.version.slice(1).split('.');
+    parsedVersionArray.map((v, index) => {
+      if (index != 0 && parseInt(v) != 0) {
+        currLogger.warn(`${spec.$schema} can not be resolved`);
+        return;
+      }
+    });
     if (!satisfies(version, `^${parsed.version.slice(1)}`))
       currLogger.warn(`The input spec uses Vega ${parsed.version}, but the current version of Vega is v${version}.`);
 
@@ -223,6 +230,13 @@ function parseVegaLite(
     };
 
     const parsed = schemaParser(vegaLiteSpec.$schema);
+    const parsedVersionArray = parsed.version.slice(1).split('.');
+    parsedVersionArray.map((v, index) => {
+      if (index != 0 && parseInt(v) != 0) {
+        currLogger.warn(`${vegaLiteSpec.$schema} can not be resolved`);
+        return;
+      }
+    });
 
     if (!satisfies(vegaLite.version, `^${parsed.version.slice(1)}`))
       currLogger.warn(


### PR DESCRIPTION
Fix #447 
 * added warning for mismatch of current vega and vegaLite with the spec version input by user
![screen-cast-2020-02-19_02 04 42](https://user-images.githubusercontent.com/41939219/74776801-3f733480-52be-11ea-9b53-6acb3ea18ad3.gif)
