### PR TITLE
Add VS Code format rule to remove spaces after opening and before closing non-empty braces

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,7 @@
 {
   "typescript.tsdk": "node_modules/typescript/lib",
   "editor.formatOnSave": true,
+  "typescript.format.insertSpaceAfterOpeningAndBeforeClosingNonemptyBraces": false,
   "eslint.validate": [
     "javascript",
     "javascriptreact",


### PR DESCRIPTION
With the `"editor.formatOnSave": true` [in the settings.json](https://github.com/vega/editor/blob/master/.vscode/settings.json#L3) my VS Code introduced a lot of spaces inside the curly braced object definitions so I've added this setting to keep the currently present code format:
```json
"typescript.format.insertSpaceAfterOpeningAndBeforeClosingNonemptyBraces": false, 
```
> Defines space handling after opening and before closing non-empty braces. Requires using TypeScript 2.3.0 or newer in the workspace.

