### PR TITLE
Add restart option into docker compose yml file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,3 +7,4 @@ services:
       - "8080:8080"
     volumes:
       - "./src:/usr/src/app/src"
+    restart: "always"


### PR DESCRIPTION
I added `restart "always"` option into docker-compose.yml. If we add this option, we don't need to restart the container when we reboot the machine.