### PR TITLE
Version mismatch warning

### DIFF
--- a/src/reducers/index.ts
+++ b/src/reducers/index.ts
@@ -157,6 +157,13 @@ function parseVega(
     const spec = JSON.parse(action.spec);
     const parsed = schemaParser(spec.$schema);
 
+    const parsedVersionArray = parsed.version.slice(1).split('.');
+    parsedVersionArray.map((v, index) => {
+      if (index != 0 && parseInt(v) != 0) {
+        currLogger.warn(`${spec.$schema} can not be resolved`);
+        return;
+      }
+    });
     if (!satisfies(version, `^${parsed.version.slice(1)}`))
       currLogger.warn(`The input spec uses Vega ${parsed.version}, but the current version of Vega is v${version}.`);
 
@@ -223,6 +230,13 @@ function parseVegaLite(
     };
 
     const parsed = schemaParser(vegaLiteSpec.$schema);
+    const parsedVersionArray = parsed.version.slice(1).split('.');
+    parsedVersionArray.map((v, index) => {
+      if (index != 0 && parseInt(v) != 0) {
+        currLogger.warn(`${vegaLiteSpec.$schema} can not be resolved`);
+        return;
+      }
+    });
 
     if (!satisfies(vegaLite.version, `^${parsed.version.slice(1)}`))
       currLogger.warn(

--- a/src/reducers/index.ts
+++ b/src/reducers/index.ts
@@ -158,14 +158,15 @@ function parseVega(
     const parsed = schemaParser(spec.$schema);
 
     const parsedVersionArray = parsed.version.slice(1).split('.');
-    parsedVersionArray.map((v, index) => {
+    for (const [index, v] of parsedVersionArray.entries()) {
       if (index != 0 && parseInt(v) != 0) {
         currLogger.warn(`${spec.$schema} can not be resolved`);
-        return;
+        break;
       }
-    });
+    }
+
     if (!satisfies(version, `^${parsed.version.slice(1)}`))
-      currLogger.warn(`The input spec uses Vega ${parsed.version}, but the current version of Vega is v${version}.`);
+      currLogger.warn(`The input spec uses Vega ${parsed.version}, but the current version of Vega is v${version[0]}.`);
 
     validateVega(spec, currLogger);
 
@@ -231,16 +232,17 @@ function parseVegaLite(
 
     const parsed = schemaParser(vegaLiteSpec.$schema);
     const parsedVersionArray = parsed.version.slice(1).split('.');
-    parsedVersionArray.map((v, index) => {
+
+    for (const [index, v] of parsedVersionArray.entries()) {
       if (index != 0 && parseInt(v) != 0) {
         currLogger.warn(`${vegaLiteSpec.$schema} can not be resolved`);
-        return;
+        break;
       }
-    });
+    }
 
     if (!satisfies(vegaLite.version, `^${parsed.version.slice(1)}`))
       currLogger.warn(
-        `The input spec uses Vega-Lite ${parsed.version}, but the current version of Vega-Lite is v${vegaLite.version}.`
+        `The input spec uses Vega-Lite ${parsed.version}, but the current version of Vega-Lite is v${vegaLite.version[0]}.`
       );
 
     validateVegaLite(vegaLiteSpec, currLogger);

--- a/src/reducers/index.ts
+++ b/src/reducers/index.ts
@@ -1,5 +1,7 @@
 import stringify from 'json-stringify-pretty-compact';
-import {mergeConfig} from 'vega';
+import {mergeConfig, version} from 'vega';
+import {satisfies} from 'semver';
+import schemaParser from 'vega-schema-url-parser';
 import * as vegaLite from 'vega-lite';
 import {Config} from 'vega-lite/src/config';
 import {TopLevelSpec} from 'vega-lite/src/spec';
@@ -153,6 +155,10 @@ function parseVega(
 
   try {
     const spec = JSON.parse(action.spec);
+    const parsed = schemaParser(spec.$schema);
+
+    if (!satisfies(version, `^${parsed.version.slice(1)}`))
+      currLogger.warn(`The input spec uses Vega ${parsed.version}, but the current version of Vega is v${version}.`);
 
     validateVega(spec, currLogger);
 
@@ -215,6 +221,14 @@ function parseVegaLite(
       config,
       logger: currLogger,
     };
+
+    const parsed = schemaParser(vegaLiteSpec.$schema);
+
+    if (!satisfies(vegaLite.version, `^${parsed.version.slice(1)}`))
+      currLogger.warn(
+        `The input spec uses Vega-Lite ${parsed.version}, but the current version of Vega-Lite is v${vegaLite.version}.`
+      );
+
     validateVegaLite(vegaLiteSpec, currLogger);
 
     const vegaSpec = spec !== '{}' ? vegaLite.compile(vegaLiteSpec, options).spec : {};


### PR DESCRIPTION
# Resolves #447 
 * Adds warning for mismatch of current vega and vegaLite with the spec version input by user
 * Adds warning if the input spec version in not resolvable

## Screenshots

### Vega

![screen-cast-2020-05-08_14 02 19](https://user-images.githubusercontent.com/41939219/81388404-df11c780-9135-11ea-8e5f-fc4fb779a116.gif)

### Vega-Lite

![screen-cast-2020-05-08_14 03 18](https://user-images.githubusercontent.com/41939219/81388426-e5a03f00-9135-11ea-8bf9-bc06a6feec2a.gif)

