### PR TITLE
Fix Vega-Lite compiled twice

### DIFF
--- a/src/actions/editor.ts
+++ b/src/actions/editor.ts
@@ -153,17 +153,19 @@ export function setVegaLiteExample(example: string, spec) {
 }
 export type SetVegaLiteExample = ReturnType<typeof setVegaLiteExample>;
 
-export function updateVegaSpec(spec: Spec) {
+export function updateVegaSpec(spec: Spec, config: string = undefined) {
   return {
     spec,
+    config,
     type: UPDATE_VEGA_SPEC,
   };
 }
 export type UpdateVegaSpec = ReturnType<typeof updateVegaSpec>;
 
-export function updateVegaLiteSpec(spec: TopLevelSpec) {
+export function updateVegaLiteSpec(spec: TopLevelSpec, config: string = undefined) {
   return {
     spec,
+    config,
     type: UPDATE_VEGA_LITE_SPEC,
   };
 }

--- a/src/components/input-panel/spec-editor/renderer.tsx
+++ b/src/components/input-panel/spec-editor/renderer.tsx
@@ -200,8 +200,7 @@ class Editor extends React.PureComponent<Props> {
     if (this.props.parse) {
       this.editor.focus();
       this.editor.layout();
-      this.updateSpec(this.props.value);
-      prevProps.setConfig(this.props.configEditorString);
+      this.updateSpec(this.props.value, this.props.configEditorString);
       prevProps.parseSpec(false);
     }
   }
@@ -217,7 +216,7 @@ class Editor extends React.PureComponent<Props> {
     document.removeEventListener('keydown', this.handleKeydown);
   }
 
-  public updateSpec(spec: string) {
+  public updateSpec(spec: string, config: string = undefined) {
     let parsedMode = this.props.mode;
 
     try {
@@ -239,10 +238,10 @@ class Editor extends React.PureComponent<Props> {
 
     switch (parsedMode) {
       case Mode.Vega:
-        this.props.updateVegaSpec(spec);
+        this.props.updateVegaSpec(spec, config);
         break;
       case Mode.VegaLite:
-        this.props.updateVegaLiteSpec(spec);
+        this.props.updateVegaLiteSpec(spec, config);
         break;
       default:
         console.exception(`Unknown mode:  ${parsedMode}`);

--- a/src/reducers/index.ts
+++ b/src/reducers/index.ts
@@ -54,6 +54,7 @@ import {
   WARN,
   ERROR,
   SET_COMPILEDPANE_ITEM,
+  setConfig,
 } from '../actions/editor';
 import {DEFAULT_STATE, GistPrivacy, Mode} from '../constants';
 import {State} from '../constants/default-state';
@@ -359,7 +360,12 @@ export default (state: State = DEFAULT_STATE, action: Action): State => {
       });
     }
     case UPDATE_VEGA_SPEC: {
-      return parseVega(state, action);
+      if (action.config !== undefined) {
+        const newState = parseConfig(state, setConfig(action.config));
+        return parseVega(newState, action);
+      } else {
+        return parseVega(state, action);
+      }
     }
     case SET_GIST_VEGA_SPEC: {
       return parseVega(state, action, {
@@ -372,7 +378,11 @@ export default (state: State = DEFAULT_STATE, action: Action): State => {
       });
     }
     case UPDATE_VEGA_LITE_SPEC: {
-      return parseVegaLite(state, action);
+      if (action.config !== undefined) {
+        return parseVegaLite(state, action, {configEditorString: action.config});
+      } else {
+        return parseVegaLite(state, action);
+      }
     }
     case SET_GIST_VEGA_LITE_SPEC: {
       return parseVegaLite(state, action, {


### PR DESCRIPTION
The issue is that we are dispatching two actions: updateVegaLiteSpec and then setConfig, each calls VL compile once.
The fix basically make the updateVegaLiteSpec and updateVegaSpec action optionally take a config parameter, and in the reducer incorporate the config.

Fix #536 