### PR TITLE
Add Dataflow Viewer

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "d3-geo-projection": "^3.0.0",
     "d3-scale": "^3.3.0",
     "file-loader": "^6.2.0",
+    "graphviz-react": "1.2.0",
     "history": "^5.0.0",
     "json-stringify-pretty-compact": "^3.0.0",
     "lz-string": "^1.4.4",

--- a/src/components/dataflow-viewer/index.css
+++ b/src/components/dataflow-viewer/index.css
@@ -1,0 +1,5 @@
+.dataflow-pane {
+  overflow: auto;
+  width: 100%;
+  flex: 1;
+}

--- a/src/components/dataflow-viewer/index.tsx
+++ b/src/components/dataflow-viewer/index.tsx
@@ -1,0 +1,12 @@
+import {connect} from 'react-redux';
+import {State} from '../../constants/default-state';
+import Renderer from './renderer';
+
+export function mapStateToProps(state: State) {
+  return {
+    editorRef: state.editorRef,
+    view: state.view,
+  };
+}
+
+export default connect(mapStateToProps)(Renderer);

--- a/src/components/dataflow-viewer/renderer.tsx
+++ b/src/components/dataflow-viewer/renderer.tsx
@@ -1,0 +1,55 @@
+import {Graphviz} from 'graphviz-react';
+import * as React from 'react';
+import {useEffect, useRef, useState} from 'react';
+import {mapStateToProps} from '.';
+import {view2dot} from '../../utils/view2dot';
+import './index.css';
+
+type StoreProps = ReturnType<typeof mapStateToProps>;
+
+export default function DataflowViewer({view}: StoreProps) {
+  const componentRef = useRef();
+
+  const dot = view2dot(view, 0);
+  // TODO: Use webworker for graphviz
+  // https://github.com/DomParfitt/graphviz-react/issues/37
+
+  // Can't set to parent width, so manually get parent container and use this to set
+  // https://github.com/DomParfitt/graphviz-react/issues/11
+  const {width, height} = useContainerDimensions(componentRef);
+  return (
+    <div ref={componentRef} className="dataflow-pane">
+      <Graphviz dot={dot} options={{fit: true, zoom: true, width, height}} />
+    </div>
+  );
+}
+
+/**
+ * From https://stackoverflow.com/a/60978633/907060
+ */
+export const useContainerDimensions = (myRef) => {
+  const getDimensions = () => ({
+    width: myRef.current.offsetWidth,
+    height: myRef.current.offsetHeight,
+  });
+
+  const [dimensions, setDimensions] = useState({width: 0, height: 0});
+
+  useEffect(() => {
+    const handleResize = () => {
+      setDimensions(getDimensions());
+    };
+
+    if (myRef.current) {
+      setDimensions(getDimensions());
+    }
+
+    window.addEventListener('resize', handleResize);
+
+    return () => {
+      window.removeEventListener('resize', handleResize);
+    };
+  }, [myRef]);
+
+  return dimensions;
+};

--- a/src/components/viz-pane/debug-pane-header/index.tsx
+++ b/src/components/viz-pane/debug-pane-header/index.tsx
@@ -71,6 +71,20 @@ class DebugPaneHeader extends React.PureComponent<Props> {
               Signal Viewer
             </li>
           )}
+          {error === null && (
+            <li
+              className={navItem === NAVBAR.DataflowViewer ? 'active-tab' : undefined}
+              onClick={(e) => {
+                if (debugPane) {
+                  e.stopPropagation();
+                }
+                showLogs(false);
+                toggleNavbar(NAVBAR.DataflowViewer);
+              }}
+            >
+              Dataflow Viewer
+            </li>
+          )}
         </ul>
         {debugPane ? <ChevronDown /> : <ChevronUp />}
       </div>

--- a/src/components/viz-pane/renderer.tsx
+++ b/src/components/viz-pane/renderer.tsx
@@ -1,17 +1,18 @@
 import * as React from 'react';
 import SplitPane from 'react-split-pane';
+import {version as VG_VERSION} from 'vega';
+import {version as VL_VERSION} from 'vega-lite';
+import {version as TOOLTIP_VERSION} from 'vega-tooltip';
 import {mapDispatchToProps, mapStateToProps} from '.';
 import {EDITOR_FOCUS, LAYOUT, NAVBAR, WORD_SEPARATORS} from '../../constants';
 import DataViewer from '../data-viewer';
+import DataflowViewer from '../dataflow-viewer';
 import ErrorBoundary from '../error-boundary';
 import ErrorPane from '../error-pane';
 import Renderer from '../renderer';
 import SignalViewer from '../signal-viewer';
 import DebugPaneHeader from './debug-pane-header';
 import './index.css';
-import {version as VG_VERSION} from 'vega';
-import {version as VL_VERSION} from 'vega-lite';
-import {version as TOOLTIP_VERSION} from 'vega-tooltip';
 const pjson = require('../../../package.json');
 
 const defaultState = {
@@ -98,6 +99,8 @@ export default class VizPane extends React.PureComponent<Props, State> {
           return <DataViewer onClickHandler={(header) => this.onClickHandler(header)} />;
         case NAVBAR.SignalViewer:
           return <SignalViewer onClickHandler={(header) => this.onClickHandler(header)} />;
+        case NAVBAR.DataflowViewer:
+          return <DataflowViewer />;
         default:
           return null;
       }

--- a/src/constants/consts.ts
+++ b/src/constants/consts.ts
@@ -47,6 +47,7 @@ export const NAVBAR = {
   DataViewer: 'DataViewer',
   Logs: 'Logs',
   SignalViewer: 'SignalViewer',
+  DataflowViewer: 'DataflowViewer',
 } as const;
 
 export const SIDEPANE = {

--- a/src/utils/view2dot.ts
+++ b/src/utils/view2dot.ts
@@ -1,0 +1,194 @@
+// Copy of https://observablehq.com/@vega/vega2dot
+
+/**
+ * Generates a dot-formatted file for Graphviz to visualize the dataflow
+ * graph for a Vega View instance.
+ * Note: does not (yet) support nested scopes / subflows.
+ * @param {View} view A Vega View instance.
+ * @param {number} [stamp] Optional pulse timestamp. If provided, dataflow
+ *   nodes and edges that have not been evaluated since the timestamp will
+ *   be deemphasized.
+ * @returns {string} The generated dot file.
+ */
+export function view2dot(view, stamp) {
+  const rt = view._runtime,
+    ops = rt.nodes,
+    keys = Object.keys(ops);
+
+  const signals = Object.keys(rt.signals).reduce((lut, name) => {
+    lut[rt.signals[name].id] = name;
+    return lut;
+  }, {});
+
+  const scales = Object.keys(rt.scales).reduce((lut, name) => {
+    lut[rt.scales[name].id] = name;
+    return lut;
+  }, {});
+
+  const data = Object.keys(rt.data).reduce((lut, name) => {
+    const sets = rt.data[name];
+    if (sets.input) lut[sets.input.id] = name;
+    if (sets.output) lut[sets.output.id] = name;
+    return lut;
+  }, {});
+
+  // build node objects
+  const nodes = keys.map((key) => {
+    const op = ops[key];
+    const node: any = {
+      id: op.id,
+      type: op.constructor.name.toLowerCase(),
+      stamp: op.stamp,
+      value: op,
+    };
+    if (markTypes[getType(node.type)]) node.isMark = true;
+    if (signals[op.id]) node.signal = signals[op.id];
+    if (scales[op.id]) node.scale = scales[op.id];
+    if (data[op.id]) node.data = data[op.id];
+    if (rt.root === op) node.root = true;
+    return node;
+  });
+
+  const ids = nodes.reduce((lut, node) => {
+    lut[node.id] = node;
+    return lut;
+  }, {});
+
+  // build edge objects
+  const edges = [];
+  keys.forEach((key) => {
+    const op = ops[key];
+    if (op._targets)
+      op._targets.forEach((t) => {
+        if (!ids[t.id]) return;
+        edges.push({
+          nodes: [op.id, t.id],
+          param: t.source === op ? 'pulse' : argop(t, op),
+        });
+        if (t.source === op && ids[op.id].isMark) {
+          const node = ids[t.id];
+          if (getType(node.type) === 'collect') {
+            // annotate post-datajoin collect operators as mark-processing
+            node.isMark = true;
+          }
+        }
+      });
+  });
+
+  return `digraph {
+    rankdir = LR;
+    node [style=filled];
+    ${nodes
+      .map((node) => {
+        return (
+          node.id +
+          ' [label="' +
+          nodeLabel(node) +
+          '"]' +
+          ' [color="' +
+          nodeColor(node, stamp) +
+          '"]' +
+          ' [fillcolor="' +
+          nodeFillColor(node, stamp) +
+          '"]' +
+          ' [fontcolor="' +
+          nodeFontColor(node, stamp) +
+          '"]'
+        );
+      })
+      .join(';\n  ')};
+    ${edges
+      .map((e) => {
+        return (
+          e.nodes.join(' -> ') +
+          ' [label="' +
+          (e.param === 'pulse' ? '' : e.param) +
+          '"]' +
+          ' [color="' +
+          edgeColor(e, ids, stamp) +
+          '"]' +
+          ' [fontcolor="' +
+          edgeLabelColor(e, ids, stamp) +
+          '"]' +
+          ' [weight="' +
+          edgeWeight(e, ids) +
+          '"]'
+        );
+      })
+      .join(';\n  ')};
+  }`;
+}
+
+function nodeLabel(node) {
+  return node.signal
+    ? node.signal
+    : node.scale
+    ? node.scale
+    : node.root
+    ? 'root'
+    : getType(node.type) === 'collect' && node.data
+    ? node.data
+    : getType(node.type);
+}
+
+function nodeFillColor(node, stamp) {
+  return stamp && node.value.stamp < stamp
+    ? '#ffffff'
+    : node.signal
+    ? '#dddddd'
+    : node.scale
+    ? '#ccffcc'
+    : node.data
+    ? '#ffcccc'
+    : getType(node.type) === 'axisticks' || getType(node.type) === 'legendentries'
+    ? '#ffcccc'
+    : node.isMark || node.root
+    ? '#ccccff'
+    : '#ffffff';
+}
+
+function nodeColor(node, stamp) {
+  return stamp && node.value.stamp < stamp ? '#dddddd' : '#000000';
+}
+
+function nodeFontColor(node, stamp) {
+  return stamp && node.value.stamp < stamp ? '#cccccc' : '#000000';
+}
+
+function edgeColor(edge, nodes, stamp) {
+  const n = edge.nodes;
+  return stamp && nodes[n[0]].value.stamp < stamp ? '#dddddd' : edge.param !== 'pulse' ? '#aaaaaa' : '#000000';
+}
+
+function edgeLabelColor(edge, nodes, stamp) {
+  const n = edge.nodes;
+  return stamp && nodes[n[0]].value.stamp < stamp ? '#dddddd' : '#000000';
+}
+function edgeWeight(edge, nodes) {
+  const n = edge.nodes;
+  return edge.param !== 'pulse' ? 1 : nodes[n[0]].isMark && nodes[n[1]].isMark ? 100 : 2;
+}
+
+function argop(t, s) {
+  if (t._argops)
+    for (const v of t._argops) {
+      if (v.op === s) return v.name;
+    }
+  return '';
+}
+
+function getType(type) {
+  const cut = type ? type.indexOf('$') : -1;
+  return cut < 0 ? type : type.slice(0, cut);
+}
+
+const markTypes = {
+  datajoin: 1,
+  encode: 1,
+  mark: 1,
+  bound: 1,
+  overlap: 1,
+  sortitems: 1,
+  render: 1,
+  viewlayout: 1,
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -3244,6 +3244,11 @@ csstype@^3.0.2:
   dependencies:
     internmap "^1.0.0"
 
+d3-color@1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/d3-color/-/d3-color-1.4.1.tgz#c52002bf8846ada4424d55d97982fef26eb3bc8a"
+  integrity sha512-p2sTHSLCJI2QKunbGb7ocOh7DgTAn8IrLx21QRc/BSnodXM4sv6aLQlnfpvehFMLZEfBc6g9pH9SWQccFYfJ9Q==
+
 "d3-color@1 - 2", d3-color@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/d3-color/-/d3-color-2.0.0.tgz#8d625cab42ed9b8f601a1760a389f7ea9189d62e"
@@ -3256,10 +3261,23 @@ d3-delaunay@^5.3.0:
   dependencies:
     delaunator "4"
 
+d3-dispatch@1, d3-dispatch@^1.0.3:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/d3-dispatch/-/d3-dispatch-1.0.6.tgz#00d37bcee4dd8cd97729dd893a0ac29caaba5d58"
+  integrity sha512-fVjoElzjhCEy+Hbn8KygnmMS7Or0a9sI2UzGwoB7cCtvI1XpVN9GpoYlnb3xt2YV66oXYb1fLJ8GMvP4hdU1RA==
+
 "d3-dispatch@1 - 2":
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/d3-dispatch/-/d3-dispatch-2.0.0.tgz#8a18e16f76dd3fcaef42163c97b926aa9b55e7cf"
   integrity sha512-S/m2VsXI7gAti2pBoLClFFTMOO1HTtT0j99AuXLoGFKO6deHDdnv6ZGTxSTTUTgO1zVcv82fCOtDjYK4EECmWA==
+
+d3-drag@1:
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/d3-drag/-/d3-drag-1.2.5.tgz#2537f451acd39d31406677b7dc77c82f7d988f70"
+  integrity sha512-rD1ohlkKQwMZYkQlYVCrSFxsWPzI97+W+PaEIBNTMxRuxz9RF0Hi5nJWHGVJ3Om9d2fRTe1yOBINJyy/ahV95w==
+  dependencies:
+    d3-dispatch "1"
+    d3-selection "1"
 
 d3-dsv@^2.0.0:
   version "2.0.0"
@@ -3269,6 +3287,11 @@ d3-dsv@^2.0.0:
     commander "2"
     iconv-lite "0.4"
     rw "1"
+
+d3-ease@1:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/d3-ease/-/d3-ease-1.0.7.tgz#9a834890ef8b8ae8c558b2fe55bd57f5993b85e2"
+  integrity sha512-lx14ZPYkhNx0s/2HX5sLFUI3mbasHjSSpwO/KaaNACweVwxUruKyWVcb293wMv1RqTPZyZ8kSZ2NogUZNcLOFQ==
 
 d3-force@^2.1.1:
   version "2.1.1"
@@ -3283,6 +3306,11 @@ d3-force@^2.1.1:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/d3-format/-/d3-format-2.0.0.tgz#a10bcc0f986c372b729ba447382413aabf5b0767"
   integrity sha512-Ab3S6XuE/Q+flY96HXT0jOXcM4EAClYFnRGY5zsjRGNy6qCYrQsMffs7cV5Q9xejb35zxW5hf/guKw34kvIKsA==
+
+d3-format@^1.2.0:
+  version "1.4.5"
+  resolved "https://registry.yarnpkg.com/d3-format/-/d3-format-1.4.5.tgz#374f2ba1320e3717eb74a9356c67daee17a7edb4"
+  integrity sha512-J0piedu6Z8iB6TbIGfZgDzfXxUFN3qQRMofy2oPdXzQibYGqPB/9iMcxr/TGalU+2RsyDO+U4f33id8tbnSRMQ==
 
 d3-geo-projection@^3.0.0:
   version "3.0.0"
@@ -3301,10 +3329,32 @@ d3-geo-projection@^3.0.0:
   dependencies:
     d3-array ">=2.5"
 
+d3-graphviz@^2.6.1:
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/d3-graphviz/-/d3-graphviz-2.6.1.tgz#61b93fe330e6339198fd2090f8080d7d4282c514"
+  integrity sha512-878AFSagQyr5tTOrM7YiVYeUC2/NoFcOB3/oew+LAML0xekyJSw9j3WOCUMBsc95KYe9XBYZ+SKKuObVya1tJQ==
+  dependencies:
+    d3-dispatch "^1.0.3"
+    d3-format "^1.2.0"
+    d3-interpolate "^1.1.5"
+    d3-path "^1.0.5"
+    d3-selection "^1.1.0"
+    d3-timer "^1.0.6"
+    d3-transition "^1.1.1"
+    d3-zoom "^1.5.0"
+    viz.js "^1.8.2"
+
 d3-hierarchy@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/d3-hierarchy/-/d3-hierarchy-2.0.0.tgz#dab88a58ca3e7a1bc6cab390e89667fcc6d20218"
   integrity sha512-SwIdqM3HxQX2214EG9GTjgmCc/mbSx4mQBn+DuEETubhOw6/U3fmnji4uCVrmzOydMHSO1nZle5gh6HB/wdOzw==
+
+d3-interpolate@1, d3-interpolate@^1.1.5:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/d3-interpolate/-/d3-interpolate-1.4.0.tgz#526e79e2d80daa383f9e0c1c1c7dcc0f0583e987"
+  integrity sha512-V9znK0zc3jOPV4VD2zZn0sDhZU3WAE2bmlxdIwwQPPzPjvyLkd8B3JUVdS1IDUFDkWZ72c9qnv1GK2ZagTZ8EA==
+  dependencies:
+    d3-color "1"
 
 "d3-interpolate@1.2.0 - 2", d3-interpolate@^2.0.1:
   version "2.0.1"
@@ -3317,6 +3367,11 @@ d3-hierarchy@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/d3-path/-/d3-path-2.0.0.tgz#55d86ac131a0548adae241eebfb56b4582dd09d8"
   integrity sha512-ZwZQxKhBnv9yHaiWd6ZU4x5BtCQ7pXszEV9CU6kRgwIQVQGLMv1oiL4M+MK/n79sYzsj+gcgpPQSctJUsLN7fA==
+
+d3-path@^1.0.5:
+  version "1.0.9"
+  resolved "https://registry.yarnpkg.com/d3-path/-/d3-path-1.0.9.tgz#48c050bb1fe8c262493a8caf5524e3e9591701cf"
+  integrity sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg==
 
 "d3-quadtree@1 - 2":
   version "2.0.0"
@@ -3333,6 +3388,11 @@ d3-scale@^3.2.2, d3-scale@^3.3.0:
     d3-interpolate "1.2.0 - 2"
     d3-time "^2.1.1"
     d3-time-format "2 - 3"
+
+d3-selection@1, d3-selection@^1.1.0:
+  version "1.4.2"
+  resolved "https://registry.yarnpkg.com/d3-selection/-/d3-selection-1.4.2.tgz#dcaa49522c0dbf32d6c1858afc26b6094555bc5c"
+  integrity sha512-SJ0BqYihzOjDnnlfyeHT0e30k0K1+5sR3d5fNueCNeuhZTnGw4M4o8mqJchSwgKMXCNFo+e2VTChiSJ0vYtXkg==
 
 d3-shape@^2.0.0:
   version "2.1.0"
@@ -3355,10 +3415,38 @@ d3-shape@^2.0.0:
   dependencies:
     d3-array "2"
 
+d3-timer@1, d3-timer@^1.0.6:
+  version "1.0.10"
+  resolved "https://registry.yarnpkg.com/d3-timer/-/d3-timer-1.0.10.tgz#dfe76b8a91748831b13b6d9c793ffbd508dd9de5"
+  integrity sha512-B1JDm0XDaQC+uvo4DT79H0XmBskgS3l6Ve+1SBCfxgmtIb1AVrPIoqd+nPSv+loMX8szQ0sVUhGngL7D5QPiXw==
+
 "d3-timer@1 - 2", d3-timer@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/d3-timer/-/d3-timer-2.0.0.tgz#055edb1d170cfe31ab2da8968deee940b56623e6"
   integrity sha512-TO4VLh0/420Y/9dO3+f9abDEFYeCUr2WZRlxJvbp4HPTQcSylXNiL6yZa9FIUvV1yRiFufl1bszTCLDqv9PWNA==
+
+d3-transition@1, d3-transition@^1.1.1:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/d3-transition/-/d3-transition-1.3.2.tgz#a98ef2151be8d8600543434c1ca80140ae23b398"
+  integrity sha512-sc0gRU4PFqZ47lPVHloMn9tlPcv8jxgOQg+0zjhfZXMQuvppjG6YuwdMBE0TuqCZjeJkLecku/l9R0JPcRhaDA==
+  dependencies:
+    d3-color "1"
+    d3-dispatch "1"
+    d3-ease "1"
+    d3-interpolate "1"
+    d3-selection "^1.1.0"
+    d3-timer "1"
+
+d3-zoom@^1.5.0:
+  version "1.8.3"
+  resolved "https://registry.yarnpkg.com/d3-zoom/-/d3-zoom-1.8.3.tgz#b6a3dbe738c7763121cd05b8a7795ffe17f4fc0a"
+  integrity sha512-VoLXTK4wvy1a0JpH2Il+F2CiOhVu7VRXWF5M/LroMIh3/zBAC3WAt7QoIvPibOavVo20hN6/37vwAsdBejLyKQ==
+  dependencies:
+    d3-dispatch "1"
+    d3-drag "1"
+    d3-interpolate "1"
+    d3-selection "1"
+    d3-transition "1"
 
 dashdash@^1.12.0:
   version "1.14.1"
@@ -4650,6 +4738,14 @@ graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.2.0,
   version "4.2.6"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.6.tgz#ff040b2b0853b23c3d31027523706f1885d76bee"
   integrity sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==
+
+graphviz-react@1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/graphviz-react/-/graphviz-react-1.2.0.tgz#ec2fafc5482569408576e1d6844cf62fbe8dda3d"
+  integrity sha512-C3V0LGLSs/gGskGwh5r8QGqGhc3D+H7b+vVGATG6ME5R50FYSl/cQNTTu9p4uOeWlHClVtL/wVZr+/+as9yBKg==
+  dependencies:
+    d3-graphviz "^2.6.1"
+    react "^16.13.1"
 
 growly@^1.3.0:
   version "1.3.0"
@@ -9759,6 +9855,11 @@ verror@1.10.0:
     assert-plus "^1.0.0"
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
+
+viz.js@^1.8.2:
+  version "1.8.2"
+  resolved "https://registry.yarnpkg.com/viz.js/-/viz.js-1.8.2.tgz#d9cc04cd99f98ec986bf9054db76a6cbcdc5d97a"
+  integrity sha512-W+1+N/hdzLpQZEcvz79n2IgUE9pfx6JLdHh3Kh8RGvLL8P1LdJVQmi2OsDcLdY4QVID4OUy+FPelyerX0nJxIQ==
 
 w3c-hr-time@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
This PR adds a dataflow viewer, to assist in debugging Vega visualizations.

It currently uses @jheer's [`vega2dot`](https://observablehq.com/@vega/vega2dot) which is used in the ["How Vega Works"](https://observablehq.com/@vega/how-vega-works) guide.

<img width="2048" alt="Screen Shot 2021-05-26 at 9 36 23 PM" src="https://user-images.githubusercontent.com/1186124/119752653-64fccf80-be6b-11eb-8588-17766bd6cf41.png">

Instead, we could also base this off of @chengluyu's [`vega-inspector`](https://github.com/chengluyu/vega-inspector). I haven't looked at the code yet. @domoritz also wrote a dataflow visualizer (https://github.com/vega/dataflow-vis) a while ago


TODO:

- [ ] Try out using web worker, to move Graphviz compilation off the main thread
- [ ] Possibly add ability to step through timestamps, as shown in the How Vega Works guide
- [ ] ??? other UX improvements to make the graph more usable ???
- [ ] Maybe make graph interactive, instead of rendering to SVG use a JS graph viewer. Could use [Eclipse Layout Kernel](https://github.com/kieler/elkjs) like [ipyelk](https://github.com/jupyrdf/ipyelk#screenshots) does.