### PR TITLE
fixed setImmediate bug

### DIFF
--- a/src/components/signal-viewer/renderer.tsx
+++ b/src/components/signal-viewer/renderer.tsx
@@ -153,7 +153,7 @@ export default class SignalViewer extends React.PureComponent<Props, any> {
         isHovered: false,
       },
       () => {
-        setImmediate(() =>
+        Promise.resolve().then(() =>
           this.setState({
             // remove the maskListener
             maskListener: false,

--- a/src/components/viz-pane/renderer.tsx
+++ b/src/components/viz-pane/renderer.tsx
@@ -65,7 +65,7 @@ export default class VizPane extends React.PureComponent<Props, State> {
       editor.revealRangeInCenter(rangeValue[0].range);
       editor.focus();
       editor.layout();
-      setImmediate(() => {
+      Promise.resolve().then(() => {
         (document.activeElement as HTMLElement).blur();
       });
     }


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/API/Window/setImmediate

I am not sure why there isn't support or why was this removed, anyway added a fix

EDIT : I couldn't find an alternative for setImmediate in browsers except resolving a promise so the loop moves to next tick

cc: @domoritz 