### PR TITLE
Replace json parser with jsonc.

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "elkjs": "^0.7.1",
     "history": "^5.2.0",
     "json-stringify-pretty-compact": "^3.0.0",
+    "jsonc-parser": "^3.0.0",
     "lz-string": "^1.4.4",
     "monaco-editor": "^0.30.1",
     "prettier": "^2.5.x",

--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -1,4 +1,5 @@
 import stringify from 'json-stringify-pretty-compact';
+import {parse} from 'jsonc-parser';
 import * as React from 'react';
 import {connect} from 'react-redux';
 import {RouteComponentProps, withRouter} from 'react-router-dom';
@@ -127,7 +128,7 @@ class App extends React.PureComponent<PropsType> {
       const gistData = await gistResponse.json();
       const contentResponse = await fetch(gistData.files[parameter.filename].raw_url); // fetch from raw_url to handle large files
       const content = await contentResponse.text();
-      const contentObj = JSON.parse(content);
+      const contentObj = parse(content);
 
       if (!('$schema' in contentObj)) {
         this.props.setGistVegaLiteSpec('', content);

--- a/src/components/header/gist-modal/renderer.tsx
+++ b/src/components/header/gist-modal/renderer.tsx
@@ -5,6 +5,7 @@ import {mapStateToProps} from '.';
 import GistSelectWidget from '../../gist-select-widget';
 import {Mode} from '../../../constants';
 import './index.css';
+import {parse} from 'jsonc-parser';
 
 export type Props = {
   closePortal: () => void;
@@ -179,7 +180,7 @@ class GistModal extends React.PureComponent<PropsType, State> {
             },
             () => {
               const {revision, filename} = this.state.gist;
-              JSON.parse(gistSummary.files[jsonFiles[0]].content);
+              parse(gistSummary.files[jsonFiles[0]].content);
               if (this.state.latestRevision) {
                 this.props.history.push(`/gist/${gistId}/${filename}`);
               } else {
@@ -199,7 +200,9 @@ class GistModal extends React.PureComponent<PropsType, State> {
         }
 
         const rawResponse = await fetch(gistSummary.files[this.state.gist.filename].raw_url); // fetch from raw_url to handle large files
-        await rawResponse.json(); // check if the loaded file is a JSON
+        const errors = [];
+        parse(await rawResponse.text(), errors);
+        if (errors.length > 0) throw SyntaxError; // check if the loaded file is a JSON
 
         const {revision, filename} = this.state.gist;
         if (this.state.latestRevision) {

--- a/src/components/header/share-modal/renderer.tsx
+++ b/src/components/header/share-modal/renderer.tsx
@@ -1,3 +1,5 @@
+import stringify from 'json-stringify-pretty-compact';
+import {parse} from 'jsonc-parser';
 import LZString from 'lz-string';
 import * as React from 'react';
 import Clipboard from 'react-clipboard.js';
@@ -54,9 +56,7 @@ class ShareModal extends React.PureComponent<Props, State> {
   }
 
   public exportURL() {
-    const specString = this.state.whitespace
-      ? this.props.editorString
-      : JSON.stringify(JSON.parse(this.props.editorString));
+    const specString = this.state.whitespace ? this.props.editorString : JSON.stringify(parse(this.props.editorString));
 
     const serializedSpec = LZString.compressToEncodedURIComponent(specString) + (this.state.fullScreen ? '/view' : '');
 
@@ -132,7 +132,7 @@ class ShareModal extends React.PureComponent<Props, State> {
     });
 
     const body = {
-      content: this.props.editorString,
+      content: this.state.whitespace ? this.props.editorString : stringify(parse(this.props.editorString)),
       name: this.state.gistFileName || 'spec',
       title: this.state.gistTitle,
       privacy: this.state.gistPrivate,
@@ -255,7 +255,7 @@ class ShareModal extends React.PureComponent<Props, State> {
               name="whitespace"
               onChange={this.handleWhitespaceCheck.bind(this)}
             />
-            Preserve whitespaces
+            Preserve whitespace, comments, and trailing commas
           </label>
         </div>
         <div className="sharing-buttons">
@@ -352,6 +352,17 @@ class ShareModal extends React.PureComponent<Props, State> {
                 that you can share. You can also load the specification via the Gist loading functionality in the
                 editor.
               </p>
+              <div>
+                <label className="user-pref">
+                  <input
+                    type="checkbox"
+                    defaultChecked={this.state.whitespace}
+                    name="whitespace"
+                    onChange={this.handleWhitespaceCheck.bind(this)}
+                  />
+                  Preserve whitespace, comments, and trailing commas
+                </label>
+              </div>
               <div className="share-input-container">
                 <label>
                   Title:

--- a/src/reducers/index.ts
+++ b/src/reducers/index.ts
@@ -70,6 +70,7 @@ import {
   SET_TOOLTIP,
 } from './../actions/editor';
 import {LocalLogger} from './../utils/logger';
+import {parse} from 'jsonc-parser';
 
 function errorLine(code: string, error: string) {
   const pattern = /(position\s)(\d+)/;
@@ -105,8 +106,8 @@ function mergeConfigIntoSpec(state: State) {
   let spec: TopLevelSpec;
   let config: Config;
   try {
-    spec = JSON.parse(state.editorString);
-    config = JSON.parse(state.configEditorString);
+    spec = parse(state.editorString);
+    config = parse(state.configEditorString);
     if (spec.config) {
       spec.config = vega.mergeConfig(config, spec.config);
     } else {
@@ -133,8 +134,8 @@ function extractConfig(state: State) {
   let spec: TopLevelSpec;
   let config: Config;
   try {
-    spec = JSON.parse(state.editorString);
-    config = JSON.parse(state.configEditorString);
+    spec = parse(state.editorString);
+    config = parse(state.configEditorString);
     if (spec.config) {
       config = vega.mergeConfig(config, spec.config);
       delete spec.config;
@@ -163,7 +164,7 @@ function parseVega(
   currLogger.level(state.logLevel);
 
   try {
-    const spec = JSON.parse(action.spec);
+    const spec = parse(action.spec);
 
     if (spec.$schema) {
       try {
@@ -232,8 +233,8 @@ function parseVegaLite(
         configEditorString = state.configEditorString;
     }
 
-    const vegaLiteSpec: vegaLite.TopLevelSpec = JSON.parse(spec);
-    const config: Config = JSON.parse(configEditorString);
+    const vegaLiteSpec: vegaLite.TopLevelSpec = parse(spec);
+    const config: Config = parse(configEditorString);
 
     const options = {
       config,
@@ -295,7 +296,7 @@ function parseVegaLite(
 function parseConfig(state: State, action: SetConfig, extend: Partial<State> = {}) {
   let config: Config;
   try {
-    config = JSON.parse(action.configEditorString);
+    config = parse(action.configEditorString);
   } catch (e) {
     const errorMessage = errorLine(action.configEditorString, e.message);
     console.warn(e);

--- a/src/utils/monaco.ts
+++ b/src/utils/monaco.ts
@@ -44,7 +44,9 @@ const schemas = [
 
 export default function setupMonaco() {
   Monaco.languages.json.jsonDefaults.setDiagnosticsOptions({
-    allowComments: false,
+    // allowComments: false,
+    comments: 'warning',
+    trailingCommas: 'warning',
     enableSchemaRequest: true,
     schemas,
     validate: true,

--- a/src/utils/monaco.ts
+++ b/src/utils/monaco.ts
@@ -1,4 +1,5 @@
 import stringify from 'json-stringify-pretty-compact';
+import {parse} from 'jsonc-parser';
 import * as Monaco from 'monaco-editor/esm/vs/editor/editor.api';
 import {mergeDeep} from 'vega-lite';
 import addMarkdownProps from './markdownProps';
@@ -73,7 +74,7 @@ export default function setupMonaco() {
       return [
         {
           range: model.getFullModelRange(),
-          text: stringify(JSON.parse(model.getValue())),
+          text: stringify(parse(model.getValue())),
         },
       ];
     },

--- a/src/utils/monaco.ts
+++ b/src/utils/monaco.ts
@@ -45,7 +45,6 @@ const schemas = [
 
 export default function setupMonaco() {
   Monaco.languages.json.jsonDefaults.setDiagnosticsOptions({
-    // allowComments: false,
     comments: 'warning',
     trailingCommas: 'warning',
     enableSchemaRequest: true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -5799,6 +5799,11 @@ json5@^2.1.2, json5@^2.2.0:
   dependencies:
     minimist "^1.2.5"
 
+jsonc-parser@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/jsonc-parser/-/jsonc-parser-3.0.0.tgz#abdd785701c7e7eaca8a9ec8cf070ca51a745a22"
+  integrity sha512-fQzRfAbIBnR0IQvftw9FJveWiHp72Fg20giDrHz6TdfB12UH/uue0D3hm57UB5KgAVuniLMCaS8P1IMj9NR7cA==
+
 jsonfile@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-4.0.0.tgz#8771aae0799b64076b76640fca058f9c10e33ecb"


### PR DESCRIPTION
This PR replaces the JSON parser with JSONC. JSONC is an extension of the JSON spec that includes comments and trailing commas. It's supported by Microsoft and used in Monaco and VSCode.

This should provide a significant quality-of-life improvement for people using the editor.

It's still possible to export and share JSON specs, and this is the default behavior. Users can opt-in to JSONC specs when sharing by clicking the "Preserve whitespace, comments, and trailing commas" button.