### PR TITLE
fix: preserveSymlinks for Vite

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -9,4 +9,7 @@ export default defineConfig({
     __COMMIT_HASH__: JSON.stringify(commitHash),
   },
   plugins: [react()],
+  resolve: {
+    preserveSymlinks: true
+  }
 });


### PR DESCRIPTION
To enable local development using `yarn link`