### PR TITLE
chore: Bump Vega-Lite Version from v5.15.0 to v15.16.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,21 +63,15 @@
     "vega-cli": "5.25.0",
     "vega-datasets": "^2.7.0",
     "vega-embed": "^6.22.2",
-    "vega-lite": "5.15.0",
+    "vega-lite": "5.16.1",
     "vega-schema-url-parser": "^2.2.0",
     "vega-themes": "^2.14.0",
     "vega-tooltip": "^0.33.0",
     "vega-typings": "^0.24.2"
   },
   "lint-staged": {
-    "*.{ts,tsx}": [
-      "eslint --fix",
-      "git add"
-    ],
-    "*.{js,jsx,ts,tsx,css,scss}": [
-      "prettier --write",
-      "git add"
-    ]
+    "*.{ts,tsx}": ["eslint --fix", "git add"],
+    "*.{js,jsx,ts,tsx,css,scss}": ["prettier --write", "git add"]
   },
   "scripts": {
     "start": "vite serve",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4774,10 +4774,10 @@ vega-label@~1.2.1:
     vega-scenegraph "^4.9.2"
     vega-util "^1.15.2"
 
-vega-lite@5.15.0:
-  version "5.15.0"
-  resolved "https://registry.yarnpkg.com/vega-lite/-/vega-lite-5.15.0.tgz#aa339a0f66df2ef4b02e729f446a91b502f541e9"
-  integrity sha512-Eac4VBhdtwbJQWH8m2OaRba/YVZbUHlmTAiPfiF3XIapJ73rcs+gHZBE1DfYgfoGjBN+5YJUMvdgm4UE7j/Ncg==
+vega-lite@5.16.1:
+  version "5.16.1"
+  resolved "https://registry.yarnpkg.com/vega-lite/-/vega-lite-5.16.1.tgz#7dbba606fce1c33661a9ab9611b3db32d2de3bf1"
+  integrity sha512-3iXmzdAVZCGHrvdh6hIM8OY55auXA1EIDzFLaYdq27e99Dr+WXTEa00ilqQUPdrpS0sE1ZqK4Ikhgg5x8SOtLw==
   dependencies:
     json-stringify-pretty-compact "~3.0.0"
     tslib "~2.6.2"


### PR DESCRIPTION
Bumps Vega-Lite version now that `{x|y}Offset` behaves differently.