### PR TITLE
Add id search to dataflow viewer

### DIFF
--- a/src/components/input-panel/spec-editor/renderer.tsx
+++ b/src/components/input-panel/spec-editor/renderer.tsx
@@ -198,7 +198,7 @@ class Editor extends React.PureComponent<Props> {
       prevProps.editorRef && prevProps.editorRef.deltaDecorations(prevProps.decorations, []);
     }
 
-    if (this.props.parse) {
+    if (this.editor && this.props.parse) {
       this.editor.focus();
       this.editor.layout();
       this.updateSpec(this.props.value, this.props.configEditorString);

--- a/src/features/dataflow/Sidebar.css
+++ b/src/features/dataflow/Sidebar.css
@@ -8,6 +8,7 @@
   width: 250px;
   gap: 10px;
 }
+
 .sidebar fieldset {
   overflow: hidden;
   border-color: var(--light-gray-color);
@@ -52,4 +53,24 @@
 /* Don't shrink type input */
 .type-filter {
   flex-shrink: 0;
+}
+
+.sidebar .id-filter {
+  padding-bottom: 20px;
+  flex-shrink: 0;
+}
+
+.sidebar .id-filter > div {
+  display: flex;
+  height: 30px;
+}
+
+.sidebar .id-filter > div input {
+  width: 70px;
+  height: 100%;
+}
+
+.sidebar .id-filter > div button {
+  width: 100%;
+  height: 100%;
 }

--- a/src/features/dataflow/Sidebar.tsx
+++ b/src/features/dataflow/Sidebar.tsx
@@ -3,13 +3,20 @@ import {useDispatch} from 'react-redux';
 import {useAppSelector} from '../../hooks';
 import {resetPulses, sortedPulsesSelector, pulsesEmptySelector} from './pulsesSlice';
 import './Sidebar.css';
-import {selectedPulseSelector, selectedTypesSelector, setSelectedPulse, setSelectedType} from './selectionSlice';
+import {
+  setSelectedElements,
+  selectedPulseSelector,
+  selectedTypesSelector,
+  setSelectedPulse,
+  setSelectedType,
+} from './selectionSlice';
 import {GraphType, types} from './utils/graph';
 
 export function Sidebar() {
   return (
     <div className="sidebar">
       <Types />
+      <Id />
       <Pulses />
     </div>
   );
@@ -39,6 +46,28 @@ function Type({type, label, selected}: {type: GraphType; label: string; selected
       />
       <label>{label}</label>
     </div>
+  );
+}
+
+function Id() {
+  const [searchTerm, setSearchTerm] = React.useState<string | null>(null);
+  const dispatch = useDispatch();
+  return (
+    <fieldset className="id-filter">
+      <legend>Filter by id</legend>
+      <input title="Pulse Id Search" onChange={(e) => setSearchTerm(e.target.value)} />
+      <button
+        onClick={() => {
+          if (!searchTerm) {
+            return;
+          }
+          dispatch(setSelectedElements({nodes: [searchTerm], edges: []}));
+          setSearchTerm(null);
+        }}
+      >
+        Search
+      </button>
+    </fieldset>
   );
 }
 

--- a/src/features/dataflow/Sidebar.tsx
+++ b/src/features/dataflow/Sidebar.tsx
@@ -54,19 +54,21 @@ function Id() {
   const dispatch = useDispatch();
   return (
     <fieldset className="id-filter">
-      <legend>Filter by id</legend>
-      <input title="Pulse Id Search" onChange={(e) => setSearchTerm(e.target.value)} />
-      <button
-        onClick={() => {
-          if (!searchTerm) {
-            return;
-          }
-          dispatch(setSelectedElements({nodes: [searchTerm], edges: []}));
-          setSearchTerm(null);
-        }}
-      >
-        Search
-      </button>
+      <legend>Filter by ID</legend>
+      <div>
+        <input type="search" title="Pulse Id Search" onChange={(e) => setSearchTerm(e.target.value)} />
+        <button
+          onClick={() => {
+            if (!searchTerm) {
+              return;
+            }
+            dispatch(setSelectedElements({nodes: [searchTerm], edges: []}));
+            setSearchTerm(null);
+          }}
+        >
+          Search
+        </button>
+      </div>
     </fieldset>
   );
 }

--- a/src/features/dataflow/utils/allRelated.ts
+++ b/src/features/dataflow/utils/allRelated.ts
@@ -26,6 +26,10 @@ export function allRelated({nodes, edges}: Graph, selected: Elements): Set<strin
         // Mark the compound node relations as visited
         // and add their immediate parents to the queue
         const node = nodes[id];
+        // if the user inputs an invalid node, just ignore it
+        if (node === undefined) {
+          continue;
+        }
         const parents = node.parent !== undefined ? [node.parent] : [];
         const relatedCompound = [...parents, ...node.children];
         relatedCompound.forEach((i) => processed.add(i));


### PR DESCRIPTION
<img width="235" alt="Screenshot 2023-11-25 at 4 55 52 PM" src="https://github.com/vega/editor/assets/6854312/6ce6e241-9a3f-4452-8e89-bd5df8939f77">

When debugging things in the vega data flow graph sometimes it can be tedious to have to manually search for a particular node of interest. This adds a _very simple_ id search which allows the user to search for a particular node