### PR TITLE
Better usage instructions and less build requirements (rm+cp instead of rsync)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ You can reset the Vega Editor by going to https://vega.github.io/editor/#/reset 
 
 ## Usage Instructions
 
-To run the editor locally, you must first install the dependencies and then launch a local web server. We assume you have [yarn](https://yarnpkg.com/) installed.
+To run the editor locally, you must first install the dependencies and then launch a local web server. We assume you have [yarn](https://yarnpkg.com/), `bash`, `curl`, and `tar` installed.
 
 1. Install the dependencies:
 

--- a/README.md
+++ b/README.md
@@ -10,21 +10,26 @@ You can reset the Vega Editor by going to https://vega.github.io/editor/#/reset 
 
 ## Usage Instructions
 
-To run the editor locally, you must first install the dependencies and then launch a local web server. We assume you have [yarn](https://yarnpkg.com/), `bash`, `curl`, and `tar` installed.
-
-1. Install the dependencies:
-
-```
-$ yarn
+### Run Vega-Editor With Docker
+```bash
+sudo docker run -it --rm -p 1234:1234 node:21 bash -xc 'mkdir -p vega/editor && git clone --depth=1 https://github.com/vega/editor.git vega/editor && cd vega/editor && yarn && yarn start'
 ```
 
-2. Start the server:
+### Development Setup
+We assume you have [yarn](https://yarnpkg.com/), `bash`, `curl`, and `tar` installed.
 
-```
-$ yarn start
-```
+Your working copy of this git repository must be located at least two levels below the system root `/`.
+E.g. `/home/user/editor` or `/vega/editor`, but not `/editor`. 
 
-3. The local web server will be accessible from [http://localhost:8080](http://localhost:8080).
+Inside your working copy ...
+
+1. Install the dependencies:  
+   `$ yarn`
+
+2. Launch the local web server:  
+   `$ yarn start`
+
+3. The local web server will be accessible via [http://localhost:1234](http://localhost:1234).
 
 ## Local Testing & Debugging
 

--- a/scripts/vendor.sh
+++ b/scripts/vendor.sh
@@ -4,37 +4,28 @@ set -e
 
 DATA=public/data
 SPEC=public/spec
-SCHEMA=schema
-
-CWD=$(pwd)
 
 echo "Copying data to '$DATA'."
-
-if [ ! -d "$DATA" ]; then
-  mkdir $DATA
-fi
-
-eval rsync -r "$CWD/node_modules/vega-datasets/data/*" $DATA
+rm -rf "$DATA"
+cp -R node_modules/vega-datasets/data/ "$DATA"
 
 echo "Copy examples to '$SPEC'."
-
-if [ ! -d "$SPEC" ]; then
-  mkdir $SPEC
-fi
 
 # without v!
 VEGA_VERSION=$(scripts/version.sh vega)
 VEGA_LITE_VERSION=$(scripts/version.sh vega-lite)
 
 pushd /tmp
-curl https://github.com/vega/vega/archive/refs/tags/v$VEGA_VERSION.tar.gz -L -o vega.tar.gz
-curl https://github.com/vega/vega-lite/archive/refs/tags/v$VEGA_LITE_VERSION.tar.gz -L -o vl.tar.gz
-tar xzf vega.tar.gz vega-$VEGA_VERSION/docs
-tar xzf vl.tar.gz vega-lite-$VEGA_LITE_VERSION/examples vega-lite-$VEGA_LITE_VERSION/site/_data
+curl "https://github.com/vega/vega/archive/refs/tags/v$VEGA_VERSION.tar.gz" -L -o vega.tar.gz
+curl "https://github.com/vega/vega-lite/archive/refs/tags/v$VEGA_LITE_VERSION.tar.gz" -L -o vl.tar.gz
+tar xzf vega.tar.gz "vega-$VEGA_VERSION/docs"
+tar xzf vl.tar.gz "vega-lite-$VEGA_LITE_VERSION/examples" "vega-lite-$VEGA_LITE_VERSION/site/_data"
 popd
 
-eval rsync -r "/tmp/vega-$VEGA_VERSION/docs/examples/*.vg.json" "$SPEC/vega"
-eval rsync -r "/tmp/vega-lite-$VEGA_LITE_VERSION/examples/specs/*.vl.json" "$SPEC/vega-lite/"
+rm -rf "$SPEC"
+mkdir -p "$SPEC/vega" "$SPEC/vega-lite"
+cp "/tmp/vega-$VEGA_VERSION/docs/examples/"*.vg.json "$SPEC/vega"
+cp "/tmp/vega-lite-$VEGA_LITE_VERSION/examples/specs/"*.vl.json "$SPEC/vega-lite/"
 
 cp "/tmp/vega-lite-$VEGA_LITE_VERSION/site/_data/examples.json" "$SPEC/vega-lite/index.json"
 cp "/tmp/vega-$VEGA_VERSION/docs/_data/examples.json" "$SPEC/vega/index.json"


### PR DESCRIPTION
This pull request improves documentation and build scripts for users who just want to run vega-editor locally.
See https://github.com/vega/editor/issues/1305 for more information.

`rsync` is no longer needed to run install/build/run vega-editor. Using standard `rm` and `cp` commands instead of `rsync` is not only more portable, but was also faster on my system. I ran multiple repeated tests ...
- on an SSD and on a 10 year old HDD,
- with and without dropping caches (`sudo sh -c 'sync && echo 3 > /proc/sys/vm/drop_caches'`) in between repeats,
- for situations where the target directories were only updated, and situations where they were initialized for the first time.

Sometimes `rsync` took 10 times as long. But it does not really matter. Copying always took < 0.5 s while the downloads from the internet were the main slowdown for me.

This pull request also fixes some bugs in `scripts/vendor.sh`, e.g.
- Spaces and special symbols ``* ? [] $ ` `` are now supported in the (absolute) path of all files involved.
- When an example is removed from the source dirs, it is now removed in the (existing) target dirs too (basically `rsync`'s `--delete` option, which wasn't used so far)

Documentation was improved, so that other requirements (which are not changed in this pull request) are explicitly mentioned.

The oddity that the working copy cannot be directly below the root directory comes from below line in `package.json` ...
```json
"scripts": {
  "start": "PARCEL_BUILD_COMMIT_HASH=$(git rev-parse HEAD) parcel --watch-dir .. index.html",
```
The parent directory `..` could be `/` which `parcel` does not like. In such a situation it prints `[Error: Invalid argument]` and terminates with exit code 1.  
This could be fixed by changing `parcel --watch-dir ..` to `parcel --watch-dir .` or leaving out the option completely. However, I am not sure if that would have negative effects on the developers. I assume they have multiple vega subprojects checked out in one shared top level directory `vega/` (e.g. `vega/editor`, `vega/lite`, ...) and actually want the `..` . Therefore I only commented on it.