### PR TITLE
README.md development setup for apple silicon and others

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,9 +25,7 @@ Inside your working copy ...
 
 1. Install the dependencies:  
    `$ npm install`
-   * macOS Apple Silicon: if you encounter installation errors related to `canvas`, ensure the necessary system libraries are present by running:   
-     `$ brew install pkg-config cairo pango libpng jpeg giflib librsvg pixman python-setuptools`  
-     For more details, refer to the [canvas installation guide](https://github.com/Automattic/node-canvas?tab=readme-ov-file#installation)
+   * If you are running into issues with installing canvas, follow the [canvas installation guide](https://github.com/Automattic/node-canvas?tab=readme-ov-file#installation).
 
 2. Launch the local web server:  
    `$ npm start`


### PR DESCRIPTION
- [x] This PR is atomic (i.e., it fixes one issue at a time).
- [x] The title is a concise [semantic commit message](https://www.conventionalcommits.org/) (e.g. "fix: correctly handle undefined properties").

I noticed a week ago you migrated from `yarn` to `npm`, however I tried setting up the project for the first time today and I was running into issues when running `npm install` (`command failed: yarn run postinstall-postinstall`), until I used the correct yarn version (v1). Originally included this in the readme but removed since I don't know if that will be fixed, should I create an issue?