### PR TITLE
fix(build): import types from `vega-lite` root instead of /src directory

### DIFF
--- a/src/reducers/index.ts
+++ b/src/reducers/index.ts
@@ -2,8 +2,8 @@ import stringify from 'json-stringify-pretty-compact';
 import {satisfies} from 'semver';
 import * as vega from 'vega';
 import * as vegaLite from 'vega-lite';
-import {Config} from 'vega-lite/src/config';
-import {TopLevelSpec} from 'vega-lite/src/spec';
+import {Config} from 'vega-lite';
+import {TopLevelSpec} from 'vega-lite';
 import schemaParser from 'vega-schema-url-parser';
 import {
   Action,


### PR DESCRIPTION
## Motivation

- Re-enable useful CI checks in this repository
- Fixes #1462 (to unblock #1461)

## Changes

- Changes `Config` / `TopLevelSpec` to import from `vega-lite` root instead of from `vega-lite/src`, preventing extraneous typechecking

## Testing

- CI passing should be sufficient, this doesn't make any functional changes.

## Notes

- TSC always failing starting being an issue after https://github.com/vega/editor/commit/25d5233d84f55bc7d8bc60fdd74557ca41776866 
- Setting `skipLibCheck: true` in `tsconfig.json` alone does not work to prevent typechecking node modules if we are referencing the `src/` folder instead of sticking with the exported `vega-lite/src/index.ts`.
  - Similar case: https://stackoverflow.com/a/76639595/5129731

https://github.com/vega/editor/blob/780e299a5c2c375092637bb0cb8d8f2c17f0f9b2/tsconfig.json#L17