### PR TITLE
fix: handle QuotaExceededError when persisting state to localStorage

### DIFF
--- a/src/context/app-context.tsx
+++ b/src/context/app-context.tsx
@@ -47,7 +47,12 @@ export const AppContextProvider: FC<PropsWithChildren> = ({children}) => {
 
   useEffect(() => {
     if (typeof window !== 'undefined') {
-      localStorage.setItem(LOCAL_STORAGE_KEY, JSON.stringify(filterPersistedState(state)));
+      try {
+        localStorage.setItem(LOCAL_STORAGE_KEY, JSON.stringify(filterPersistedState(state)));
+      } catch (e) {
+        // QuotaExceededError: spec too large for localStorage
+        console.warn('Failed to persist state to localStorage:', e);
+      }
     }
   }, [state]);
 


### PR DESCRIPTION
## Problem

When loading a large Vega or Vega-Lite spec in the editor, the app crashes with:

> Uncaught QuotaExceededError: Failed to execute 'setItem' on 'Storage':
> Setting the value of 'state' exceeded the quota.

This happens in `src/context/app-context.tsx` at line 50, where the full
application state (including the spec string) is serialized and written
to `localStorage` on every state change. The browser's localStorage
quota is typically ~5MB, and large specs easily exceed this.

## Fix

Wrap the `localStorage.setItem` call in a try/catch block. When the
quota is exceeded, a warning is logged to the console and the editor
continues working normally. The only trade-off is that oversized specs
won't be persisted across page reloads.

## Testing

- Build passes (`npm run build`)
- Verified manually with a large spec that previously triggered the crash