### PR TITLE
fix: unwrap react-paginate default export to prevent DataViewer crash (#1591)

### DIFF
--- a/src/components/data-viewer/renderer.tsx
+++ b/src/components/data-viewer/renderer.tsx
@@ -1,6 +1,8 @@
 import * as React from 'react';
 import {useCallback, useEffect, useMemo, useReducer, useRef, useState} from 'react';
-import ReactPaginate from 'react-paginate';
+import ReactPaginateModule from 'react-paginate';
+
+const ReactPaginate = (ReactPaginateModule as any).default ?? ReactPaginateModule;
 import Select from 'react-select';
 import * as vega from 'vega';
 import {debounce} from 'vega';

--- a/src/components/gist-select-widget/renderer.tsx
+++ b/src/components/gist-select-widget/renderer.tsx
@@ -1,6 +1,8 @@
 import React, {useState, useEffect, useCallback} from 'react';
 import {File, Lock} from 'react-feather';
-import ReactPaginate from 'react-paginate';
+import ReactPaginateModule from 'react-paginate';
+
+const ReactPaginate = (ReactPaginateModule as any).default ?? ReactPaginateModule;
 
 import {GistPrivacy} from '../../constants/consts.js';
 import {getGithubToken} from '../../utils/github.js';

--- a/tests/unit/data-viewer.test.tsx
+++ b/tests/unit/data-viewer.test.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import {render} from '@testing-library/react';
+import {describe, it, expect} from 'vitest';
+
+import ReactPaginateModuleDataViewer from 'react-paginate';
+
+function unwrap(mod: any) {
+  return mod?.default ?? mod;
+}
+
+describe('react-paginate default import unwrapping (issue #1591)', () => {
+  it('resolves to a renderable React component', () => {
+    const ReactPaginate = unwrap(ReactPaginateModuleDataViewer);
+    const isValidComponent =
+      typeof ReactPaginate === 'function' ||
+      (ReactPaginate && typeof ReactPaginate === 'object' && '$$typeof' in ReactPaginate);
+    expect(isValidComponent).toBe(true);
+  });
+
+  it('renders pagination markup without crashing', () => {
+    const ReactPaginate = unwrap(ReactPaginateModuleDataViewer);
+    const {container} = render(
+      <ReactPaginate
+        previousLabel="<"
+        nextLabel=">"
+        pageCount={5}
+        marginPagesDisplayed={1}
+        pageRangeDisplayed={3}
+        onPageChange={() => {}}
+        containerClassName="pagination"
+        activeClassName="active"
+      />,
+    );
+    expect(container.querySelector('.pagination')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Fixes #1591 