### PR TITLE
fix: sync fullscreen routes

### DIFF
--- a/src/components/app-shell.tsx
+++ b/src/components/app-shell.tsx
@@ -9,8 +9,10 @@ export default function AppShell() {
     <>
       <Routes>
         <Route path="/" element={<App showExample={false} />} />
+        <Route path="/view" element={<App showExample={false} />} />
         <Route path="/reset" element={<Reset />} />
         <Route path="/edited" element={<App showExample={false} />} />
+        <Route path="/edited/view" element={<App showExample={false} />} />
         <Route path="/gist/:id/:filename" element={<App showExample={false} />} />
         <Route path="/gist/:id/:filename/view" element={<App showExample={false} />} />
         <Route path="/gist/:id/:revision/:filename" element={<App showExample={false} />} />

--- a/src/components/renderer/renderer.tsx
+++ b/src/components/renderer/renderer.tsx
@@ -126,17 +126,14 @@ export default function Renderer(props: RendererProps) {
 
   const openPortal = useCallback(() => {
     const pathname = location.pathname;
-    if (pathname !== '/' && pathname !== '/edited' && !pathname.endsWith('/view')) {
-      navigate(pathname + '/view', {replace: false});
+    if (!pathname.endsWith('/view')) {
+      navigate(pathname === '/' ? '/view' : pathname + '/view', {replace: false});
     }
   }, [location.pathname, navigate]);
 
   const closePortal = useCallback(() => {
-    const pathname = location.pathname
-      .split('/')
-      .filter((e) => e !== 'view')
-      .join('/');
-    if (pathname !== '/' && pathname !== '/edited') {
+    const pathname = location.pathname.replace(/\/view$/, '') || '/';
+    if (pathname !== location.pathname) {
       navigate(pathname, {replace: false});
     }
   }, [location.pathname, navigate]);

--- a/tests/e2e/test-runtime/urls.test.ts
+++ b/tests/e2e/test-runtime/urls.test.ts
@@ -55,21 +55,30 @@ test.describe('URL behavior', () => {
     expect(page.url()).toMatch(/#\/custom\/vega-lite$/);
   });
 
-  // Need to implement this in the editor first: https://github.com/vega/editor/issues/1508
-  // test('fullscreen appends /view to the current route and is removed on exit', async ({page}) => {
-  //   await homePage.typeInEditor(vlSpec);
-  //   await homePage.waitForVisualizationUpdate();
+  test('fullscreen appends /view to the root route and removes it on exit', async ({page}) => {
+    await page.locator('.fullscreen-open').click();
+    await homePage.waitForStableUI();
 
-  //   await page.locator('.fullscreen-open').click();
-  //   await homePage.waitForStableUI();
+    expect(page.url()).toMatch(/#\/view$/);
 
-  //   const urlAfterOpen = page.url();
-  //   expect(urlAfterOpen).toMatch(/\/view$/);
+    await page.getByRole('button', {name: 'Edit Visualization'}).click();
+    await homePage.waitForStableUI();
 
-  //   await page.getByRole('button', {name: 'Edit Visualization'}).click();
-  //   await homePage.waitForStableUI();
+    expect(page.url()).toMatch(/#\/$/);
+  });
 
-  //   const urlAfterClose = page.url();
-  //   expect(urlAfterClose).not.toMatch(/\/view$/);
-  // });
+  test('fullscreen appends /view to the edited route and removes it on exit', async ({page}) => {
+    await homePage.typeInEditor(vlSpec);
+    await homePage.waitForVisualizationUpdate();
+
+    await page.locator('.fullscreen-open').click();
+    await homePage.waitForStableUI();
+
+    expect(page.url()).toMatch(/#\/edited\/view$/);
+
+    await page.getByRole('button', {name: 'Edit Visualization'}).click();
+    await homePage.waitForStableUI();
+
+    expect(page.url()).toMatch(/#\/edited$/);
+  });
 });


### PR DESCRIPTION
## Summary

- append `/view` when fullscreen opens from the root or edited route
- add valid application routes for `/view` and `/edited/view`
- cover entering and exiting fullscreen from both routes with Playwright

## Root cause

Fullscreen URL synchronization explicitly skipped `/` and `/edited`, and the router did not mount the application at their corresponding `/view` paths.

## Validation

- `npx vitest --project unit` (37 tests)
- `npx playwright test --project=chromium` (84 tests)
- `npm run lint`
- `npx tsc`
- `npm run build`
- `git diff --check`

Closes #1508
